### PR TITLE
chore: update links to the repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Feature Request 💡
-    url: https://github.com/software-mansion-labs/react-native-rich-text-editor/discussions/new?category=ideas
+    url: https://github.com/software-mansion/react-native-enriched/discussions/new?category=ideas
     about: If you have a feature request, please create a new discussion on GitHub.
   - name: Discussions on GitHub 💬
-    url: https://github.com/software-mansion-labs/react-native-rich-text-editor/discussions
+    url: https://github.com/software-mansion/react-native-enriched/discussions
     about: If this library works as promised but you need help, please ask questions there.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,9 @@ The [example app](/example/) demonstrates usage of the library. You need to run 
 
 It is configured to use the local version of the library, so any changes you make to the library's source code will be reflected in the example app. Changes to the library's JavaScript code will be reflected in the example app without a rebuild, but native code changes will require a rebuild of the example app.
 
-If you want to use Android Studio or XCode to edit the native code, you can open the `example/android` or `example/ios` directories respectively in those editors. To edit the Objective-C or Swift files, open `example/ios/ReactNativeRichTextEditorExample.xcworkspace` in XCode and find the source files at `Pods > Development Pods > @swmansion/react-native-rich-text-editor`.
+If you want to use Android Studio or Xcode to edit the native code, you can open the `example/android` or `example/ios` directories respectively in those editors. To edit the Objective-C or Swift files, open `example/ios/EnrichedTextInputExample.xcworkspace` in Xcode and find the source files at `Pods > Development Pods > ReactNativeEnriched`.
 
-To edit the Java or Kotlin files, open `example/android` in Android studio and find the source files at `swmansion-react-native-rich-text-editor` under `Android`.
+To edit the Java or Kotlin files, open `example/android` in Android studio and find the source files at `react-native-enriched` under `Android`.
 
 You can use various commands from the root directory to work with the project.
 
@@ -50,7 +50,7 @@ yarn example ios
 To confirm that the app is running with the new architecture, you can check the Metro logs for a message like this:
 
 ```sh
-Running "ReactNativeRichTextEditorExample" with {"fabric":true,"initialProps":{"concurrentRoot":true},"rootTag":1}
+Running "EnrichedTextInputExample" with {"fabric":true,"initialProps":{"concurrentRoot":true},"rootTag":1}
 ```
 
 Note the `"fabric":true` and `"concurrentRoot":true` properties.

--- a/ReactNativeEnriched.podspec
+++ b/ReactNativeEnriched.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => min_ios_version_supported }
-  s.source       = { :git => "https://github.com/software-mansion-labs/react-native-rich-text-editor.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/software-mansion/react-native-enriched.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,cpp}"
   s.private_header_files = "ios/**/*.h"

--- a/package.json
+++ b/package.json
@@ -48,14 +48,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/software-mansion-labs/react-native-enriched.git"
+    "url": "git+https://github.com/software-mansion/react-native-enriched.git"
   },
   "author": "Software Mansion <contact@swmansion.com> (https://swmansion.com)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/software-mansion-labs/react-native-enriched/issues"
+    "url": "https://github.com/software-mansion/react-native-enriched/issues"
   },
-  "homepage": "https://github.com/software-mansion-labs/react-native-enriched#readme",
+  "homepage": "https://github.com/software-mansion/react-native-enriched#readme",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },


### PR DESCRIPTION
This PR adjusts the links to the repository after moving it to `software-mansion` organization on GitHub as well as updates the example app name where it was previously omitted.