### PR TITLE
Make iOS trailing newlines not use current typing attributes

### DIFF
--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -565,7 +565,7 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
     unichar lastChar = [currentStr.string characterAtIndex:currentStr.length-1];
     if([[NSCharacterSet newlineCharacterSet] characterIsMember:lastChar]) {
       [currentStr appendAttributedString:
-        [[NSAttributedString alloc] initWithString:@"I" attributes:textView.typingAttributes]
+        [[NSAttributedString alloc] initWithString:@"I" attributes:defaultTypingAttributes]
       ];
     }
   }


### PR DESCRIPTION
Trailing newlines on iOS need to be measured as if there was a fake `I` character to get the proper measurement. But incorrectly, current typing attributes were used for the character. This resulted in a funny thing; trailing newline would change sizes if we changed selection from a, say, heading line to non heading line. Now it uses the default typing attributes.