### PR TITLE
chore: add known limitations to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 `EnrichedTextInput`, the rich text editor component is an uncontrolled input. This means that it doesn't use any state or props to store its value, but instead directly interacts with the underlying platform-specific components. Thanks to this, the component is really performant and simple to use while offering complex and advanced features no other solution has.
 
-https://github.com/user-attachments/assets/4778d541-d967-47e7-8013-6f7c436bcb95
+<https://github.com/user-attachments/assets/4778d541-d967-47e7-8013-6f7c436bcb95>
 
 Since 2012 [Software Mansion](https://swmansion.com) is a software agency with experience in building web and mobile apps. We are Core React Native Contributors and experts in dealing with all kinds of React Native issues.
 We can help you build your next dream product –
@@ -246,6 +246,7 @@ See the [API Reference](docs/API_REFERENCE.md) for a detailed overview of all th
 - Only one level of lists is supported. We currently do not support nested lists.
 - Inline images are supported only on Android.
 - Codeblocks are supported only on Android.
+- iOS headings can't have the same `fontSize` in their config as input's `fontSize`. Doing so results in incorrect headings behavior.
 
 ## Future Plans
 


### PR DESCRIPTION
It may not be clear that we do not support nested lists (as reported in https://github.com/software-mansion/react-native-enriched/issues/187). I've added section with known limitations where we can explicitly mention such limitations