### PR TITLE
iOS 0 length range detection revamp

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2690,7 +2690,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 77a7129540c0e06ab6be9a2bcb887d3d2e594431
   ReactCodegen: b62625187ce853918021a7a9178cc406e9820d56
   ReactCommon: d07170f92e0e853091a70b2741b7c43f5dfdea73
-  ReactNativeEnriched: b11d66700889cd36c9938a825736de1929349b24
+  ReactNativeEnriched: ce7a893fdefce993826a3177da6811b513e26526
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 6af5d1e0290903c82b3e0cb6836a5f898c1c4634
 

--- a/ios/styles/BlockQuoteStyle.mm
+++ b/ios/styles/BlockQuoteStyle.mm
@@ -121,8 +121,8 @@
 - (BOOL)handleBackspaceInRange:(NSRange)range replacementText:(NSString *)text {
   if(
     [self detectStyle:_input->textView.selectedRange] &&
-     NSEqualRanges(_input->textView.selectedRange, NSMakeRange(0, 0)) &&
-     [text isEqualToString:@""]
+    NSEqualRanges(_input->textView.selectedRange, NSMakeRange(0, 0)) &&
+    [text isEqualToString:@""]
   ) {
     // removing first quote line by backspacing doesn't remove typing attributes because it doesn't run textViewDidChange
     // so we try guessing that a line should be deleted here
@@ -162,22 +162,11 @@
       }
     ];
   } else {
-    NSInteger searchLocation = range.location;
-    if(searchLocation == _input->textView.textStorage.length) {
-      NSParagraphStyle *pStyle = _input->textView.typingAttributes[NSParagraphStyleAttributeName];
-      return [self styleCondition:pStyle :NSMakeRange(0, 0)];
-    }
-    
-    NSRange paragraphRange = NSMakeRange(0, 0);
-    NSRange inputRange = NSMakeRange(0, _input->textView.textStorage.length);
-    NSParagraphStyle *paragraph = [_input->textView.textStorage
-      attribute:NSParagraphStyleAttributeName
-      atIndex:searchLocation
-      longestEffectiveRange: &paragraphRange
-      inRange:inputRange
+    return [OccurenceUtils detect:NSParagraphStyleAttributeName withInput:_input atIndex:range.location checkPrevious:YES
+      withCondition:^BOOL(id  _Nullable value, NSRange range) {
+        return [self styleCondition:value :range];
+      }
     ];
-    
-    return [self styleCondition:paragraph :NSMakeRange(0, 0)];
   }
 }
 

--- a/ios/styles/BlockQuoteStyle.mm
+++ b/ios/styles/BlockQuoteStyle.mm
@@ -118,16 +118,33 @@
   [self removeAttributes:_input->textView.selectedRange];
 }
 
-// removing first quote line by backspacing doesn't remove typing attributes because it doesn't run textViewDidChange
-// so we try guessing that a point should be deleted here
 - (BOOL)handleBackspaceInRange:(NSRange)range replacementText:(NSString *)text {
-  if([self detectStyle:_input->textView.selectedRange] &&
+  if(
+    [self detectStyle:_input->textView.selectedRange] &&
      NSEqualRanges(_input->textView.selectedRange, NSMakeRange(0, 0)) &&
      [text isEqualToString:@""]
   ) {
+    // removing first quote line by backspacing doesn't remove typing attributes because it doesn't run textViewDidChange
+    // so we try guessing that a line should be deleted here
     NSRange paragraphRange = [_input->textView.textStorage.string paragraphRangeForRange:_input->textView.selectedRange];
     [self removeAttributes:paragraphRange];
     return YES;
+  } else if(
+    [self detectStyle:_input->textView.selectedRange] &&
+    [text isEqualToString:@""]
+  ) {
+    // other case; make sure removing all the (non newline) text from a quto line also removes the line itself
+    NSRange paragraphRange = [_input->textView.textStorage.string paragraphRangeForRange:range];
+    NSValue *nonNewlineVal = [ParagraphsUtils getNonNewlineRangesIn:_input->textView range:paragraphRange].firstObject;
+    if(nonNewlineVal == nullptr) {
+      return NO;
+    }
+    NSRange nonNewlineRange = [nonNewlineVal rangeValue];
+    if(NSEqualRanges(range, nonNewlineRange)) {
+      [self removeAttributes:range];
+      [TextInsertionUtils replaceText:text at:range additionalAttributes:nullptr input:_input withSelection:YES];
+      return YES;
+    }
   }
   return NO;
 }

--- a/ios/styles/BoldStyle.mm
+++ b/ios/styles/BoldStyle.mm
@@ -98,8 +98,11 @@
       }
     ];
   } else {
-    UIFont *currentFontAttr = (UIFont *)_input->textView.typingAttributes[NSFontAttributeName];
-    return [self styleCondition:currentFontAttr :range];
+    return [OccurenceUtils detect:NSFontAttributeName withInput:_input atIndex:range.location checkPrevious:NO
+      withCondition:^BOOL(id  _Nullable value, NSRange range) {
+        return [self styleCondition:value :range];
+      }
+    ];
   }
 }
 

--- a/ios/styles/HeadingStyleBase.mm
+++ b/ios/styles/HeadingStyleBase.mm
@@ -117,11 +117,11 @@
       }
     ];
   } else {
-    UIFont *currentFontAttr = (UIFont *)[self typedInput]->textView.typingAttributes[NSFontAttributeName];
-    if(currentFontAttr == nullptr) {
-      return false;
-    }
-    return currentFontAttr.pointSize == [self getHeadingFontSize];
+    return [OccurenceUtils detect:NSFontAttributeName withInput:[self typedInput] atIndex:range.location checkPrevious:YES
+      withCondition:^BOOL(id  _Nullable value, NSRange range) {
+        return [self styleCondition:value :range];
+      }
+    ];
   }
 }
 

--- a/ios/styles/InlineCodeStyle.mm
+++ b/ios/styles/InlineCodeStyle.mm
@@ -140,8 +140,11 @@
   
     return detected;
   } else {
-    UIColor *currentBgColorAttr = (UIColor *)_input->textView.typingAttributes[NSBackgroundColorAttributeName];
-    return [self styleCondition:currentBgColorAttr :range];
+    return [OccurenceUtils detect:NSBackgroundColorAttributeName withInput:_input atIndex:range.location checkPrevious:NO
+      withCondition:^BOOL(id  _Nullable value, NSRange range) {
+        return [self styleCondition:value :range];
+      }
+    ];
   }
 }
 

--- a/ios/styles/ItalicStyle.mm
+++ b/ios/styles/ItalicStyle.mm
@@ -83,11 +83,11 @@
       }
     ];
   } else {
-    UIFont *currentFontAttr = (UIFont *)_input->textView.typingAttributes[NSFontAttributeName];
-    if(currentFontAttr == nullptr) {
-      return false;
-    }
-    return [currentFontAttr isItalic];
+    return [OccurenceUtils detect:NSFontAttributeName withInput:_input atIndex:range.location checkPrevious:NO
+      withCondition:^BOOL(id  _Nullable value, NSRange range) {
+        return [self styleCondition:value :range];
+      }
+    ];
   }
 }
 

--- a/ios/styles/OrderedListStyle.mm
+++ b/ios/styles/OrderedListStyle.mm
@@ -133,8 +133,8 @@
 - (BOOL)handleBackspaceInRange:(NSRange)range replacementText:(NSString *)text {
   if(
     [self detectStyle:_input->textView.selectedRange] &&
-     NSEqualRanges(_input->textView.selectedRange, NSMakeRange(0, 0)) &&
-     [text isEqualToString:@""]
+    NSEqualRanges(_input->textView.selectedRange, NSMakeRange(0, 0)) &&
+    [text isEqualToString:@""]
   ) {
     // removing first list point by backspacing doesn't remove typing attributes because it doesn't run textViewDidChange
     // so we try guessing that a point should be deleted here
@@ -204,22 +204,11 @@
       }
     ];
   } else {
-    NSInteger searchLocation = range.location;
-    if(searchLocation == _input->textView.textStorage.length) {
-      NSParagraphStyle *pStyle = _input->textView.typingAttributes[NSParagraphStyleAttributeName];
-      return [self styleCondition:pStyle :NSMakeRange(0, 0)];
-    }
-    
-    NSRange paragraphRange = NSMakeRange(0, 0);
-    NSRange inputRange = NSMakeRange(0, _input->textView.textStorage.length);
-    NSParagraphStyle *paragraph = [_input->textView.textStorage
-      attribute:NSParagraphStyleAttributeName
-      atIndex:searchLocation
-      longestEffectiveRange: &paragraphRange
-      inRange:inputRange
+    return [OccurenceUtils detect:NSParagraphStyleAttributeName withInput:_input atIndex:range.location checkPrevious:YES
+      withCondition:^BOOL(id  _Nullable value, NSRange range) {
+        return [self styleCondition:value :range];
+      }
     ];
-    
-    return [self styleCondition:paragraph :NSMakeRange(0, 0)];
   }
 }
 

--- a/ios/styles/StrikethroughStyle.mm
+++ b/ios/styles/StrikethroughStyle.mm
@@ -56,8 +56,11 @@
       }
     ];
   } else {
-    NSNumber *currenStrikethroughAttr = (NSNumber *)_input->textView.typingAttributes[NSStrikethroughStyleAttributeName];
-    return currenStrikethroughAttr != nullptr;
+    return [OccurenceUtils detect:NSStrikethroughStyleAttributeName withInput:_input atIndex:range.location checkPrevious:NO
+      withCondition:^BOOL(id  _Nullable value, NSRange range) {
+        return [self styleCondition:value :range];
+      }
+    ];
   }
 }
 

--- a/ios/styles/UnderlineStyle.mm
+++ b/ios/styles/UnderlineStyle.mm
@@ -88,8 +88,11 @@
       }
     ];
   } else {
-    NSNumber *currentUnderlineAttr = (NSNumber *)_input->textView.typingAttributes[NSUnderlineStyleAttributeName];
-    return [self styleCondition:currentUnderlineAttr :range];
+    return [OccurenceUtils detect:NSUnderlineStyleAttributeName withInput:_input atIndex:range.location checkPrevious:NO
+      withCondition:^BOOL(id  _Nullable value, NSRange range) {
+        return [self styleCondition:value :range];
+      }
+    ];
   }
 }
 

--- a/ios/styles/UnorderedListStyle.mm
+++ b/ios/styles/UnorderedListStyle.mm
@@ -133,8 +133,8 @@
 - (BOOL)handleBackspaceInRange:(NSRange)range replacementText:(NSString *)text {
   if(
     [self detectStyle:_input->textView.selectedRange] &&
-     NSEqualRanges(_input->textView.selectedRange, NSMakeRange(0, 0)) &&
-     [text isEqualToString:@""]
+    NSEqualRanges(_input->textView.selectedRange, NSMakeRange(0, 0)) &&
+    [text isEqualToString:@""]
   ) {
     // removing first list point by backspacing doesn't remove typing attributes because it doesn't run textViewDidChange
     // so we try guessing that a point should be deleted here
@@ -204,22 +204,11 @@
       }
     ];
   } else {
-    NSInteger searchLocation = range.location;
-    if(searchLocation == _input->textView.textStorage.length) {
-      NSParagraphStyle *pStyle = _input->textView.typingAttributes[NSParagraphStyleAttributeName];
-      return [self styleCondition:pStyle :NSMakeRange(0, 0)];
-    }
-    
-    NSRange paragraphRange = NSMakeRange(0, 0);
-    NSRange inputRange = NSMakeRange(0, _input->textView.textStorage.length);
-    NSParagraphStyle *paragraph = [_input->textView.textStorage
-      attribute:NSParagraphStyleAttributeName
-      atIndex:searchLocation
-      longestEffectiveRange: &paragraphRange
-      inRange:inputRange
+    return [OccurenceUtils detect:NSParagraphStyleAttributeName withInput:_input atIndex:range.location checkPrevious:YES
+      withCondition:^BOOL(id  _Nullable value, NSRange range) {
+        return [self styleCondition:value :range];
+      }
     ];
-    
-    return [self styleCondition:paragraph :NSMakeRange(0, 0)];
   }
 }
 

--- a/ios/utils/OccurenceUtils.h
+++ b/ios/utils/OccurenceUtils.h
@@ -9,6 +9,12 @@
   withInput:(EnrichedTextInputView* _Nonnull)input
   inRange:(NSRange)range
   withCondition:(BOOL (NS_NOESCAPE ^_Nonnull)(id _Nullable value, NSRange range))condition;
++ (BOOL)detect
+  :(NSAttributedStringKey _Nonnull)key
+  withInput:(EnrichedTextInputView* _Nonnull)input
+  atIndex:(NSUInteger)index
+  checkPrevious:(BOOL)check
+  withCondition:(BOOL (NS_NOESCAPE ^_Nonnull)(id _Nullable value, NSRange range))condition;
 + (BOOL)detectMultiple
   :(NSArray<NSAttributedStringKey> *_Nonnull)keys
   withInput:(EnrichedTextInputView* _Nonnull)input


### PR DESCRIPTION
I found a few really strange issues that resulted from previous assumptions; previously I thought detecting a style at a 0 length range was equivalent to cursor being there. Later code proved me wrong (mainly zero width space logic) and I decided to revamp the way it works.
Now:
- if cursor is at the place, just use typing attributes to retrieve needed values
- otherwise;
    - if the place is as the very end of the input, either there's no style (inline styles) or check the first character of the paragraph if it exists (paragraph styles)
    - otherwise check attributes at the given index using apple's API for this
    
Apart from that, this PR also fixes a situation where backspacing a list or blockquote wouldn't remove the style.