### PR TITLE
Unify the behavior around backspacing iOS lists and quotes

### DIFF
--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -980,8 +980,8 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
   }
   
   // typing attributes for empty lines selection reset
-  NSString *currentString = [[textView.textStorage.string copy] stringByReplacingOccurrencesOfString:@"\u200B" withString:@""];
-  if(textView.selectedRange.length == 0 && [_recentlyEmittedString isEqualToString: currentString] ) {
+  NSString *currentString = [textView.textStorage.string copy];
+  if(textView.selectedRange.length == 0 && [_recentlyEmittedString isEqualToString:currentString]) {
     // no string change means only a selection changed with no character changes
     NSRange paragraphRange = [textView.textStorage.string paragraphRangeForRange:textView.selectedRange];
     if(
@@ -1012,14 +1012,14 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
     return;
   }
   
+  // zero width space adding or removal
+  [ZeroWidthSpaceUtils handleZeroWidthSpacesInInput:self];
+  
   // emptying input typing attributes management
   if(textView.textStorage.string.length == 0 && _recentlyEmittedString.length > 0) {
     // reset typing attribtues
     textView.typingAttributes = defaultTypingAttributes;
   }
-  
-  // zero width space removal
-  [ZeroWidthSpaceUtils handleZeroWidthSpacesInInput:self];
   
   // inline code on newlines fix
   InlineCodeStyle *codeStyle = stylesDict[@([InlineCodeStyle getStyleType])];

--- a/ios/styles/OrderedListStyle.mm
+++ b/ios/styles/OrderedListStyle.mm
@@ -131,30 +131,19 @@
 }
 
 - (BOOL)handleBackspaceInRange:(NSRange)range replacementText:(NSString *)text {
-  if(
-    [self detectStyle:_input->textView.selectedRange] &&
-    NSEqualRanges(_input->textView.selectedRange, NSMakeRange(0, 0)) &&
-    [text isEqualToString:@""]
-  ) {
-    // removing first list point by backspacing doesn't remove typing attributes because it doesn't run textViewDidChange
-    // so we try guessing that a point should be deleted here
+  if([self detectStyle:_input->textView.selectedRange] && text.length == 0) {
+    // backspace while the style is active
+    
     NSRange paragraphRange = [_input->textView.textStorage.string paragraphRangeForRange:_input->textView.selectedRange];
-    [self removeAttributes:paragraphRange];
-    return YES;
-  } else if(
-    [self detectStyle:_input->textView.selectedRange] &&
-    [text isEqualToString:@""]
-  ) {
-    // other case; make sure removing all the (non newline) text from a list item also removes the item itself
-    NSRange paragraphRange = [_input->textView.textStorage.string paragraphRangeForRange:range];
-    NSValue *nonNewlineVal = [ParagraphsUtils getNonNewlineRangesIn:_input->textView range:paragraphRange].firstObject;
-    if(nonNewlineVal == nullptr) {
-      return NO;
-    }
-    NSRange nonNewlineRange = [nonNewlineVal rangeValue];
-    if(NSEqualRanges(range, nonNewlineRange)) {
-      [TextInsertionUtils replaceText:text at:range additionalAttributes:nullptr input:_input withSelection:YES];
-      [self removeAttributes:NSMakeRange(range.location, 0)];
+    
+    if(NSEqualRanges(_input->textView.selectedRange, NSMakeRange(0, 0))) {
+      // a backspace on the very first input's line list point
+      // it doesn't run textVieDidChange so we need to manually remove attributes
+      [self removeAttributes:paragraphRange];
+      return YES;
+    } else if(range.location == paragraphRange.location - 1) {
+      // same case in other lines; here, the removed range location will be exactly 1 less than paragraph range location
+      [self removeAttributes:paragraphRange];
       return YES;
     }
   }

--- a/ios/styles/UnorderedListStyle.mm
+++ b/ios/styles/UnorderedListStyle.mm
@@ -131,30 +131,19 @@
 }
 
 - (BOOL)handleBackspaceInRange:(NSRange)range replacementText:(NSString *)text {
-  if(
-    [self detectStyle:_input->textView.selectedRange] &&
-    NSEqualRanges(_input->textView.selectedRange, NSMakeRange(0, 0)) &&
-    [text isEqualToString:@""]
-  ) {
-    // removing first list point by backspacing doesn't remove typing attributes because it doesn't run textViewDidChange
-    // so we try guessing that a point should be deleted here
+  if([self detectStyle:_input->textView.selectedRange] && text.length == 0) {
+    // backspace while the style is active
+    
     NSRange paragraphRange = [_input->textView.textStorage.string paragraphRangeForRange:_input->textView.selectedRange];
-    [self removeAttributes:paragraphRange];
-    return YES;
-  } else if(
-    [self detectStyle:_input->textView.selectedRange] &&
-    [text isEqualToString:@""]
-  ) {
-    // other case; make sure removing all the (non newline) text from a list item also removes the item itself
-    NSRange paragraphRange = [_input->textView.textStorage.string paragraphRangeForRange:range];
-    NSValue *nonNewlineVal = [ParagraphsUtils getNonNewlineRangesIn:_input->textView range:paragraphRange].firstObject;
-    if(nonNewlineVal == nullptr) {
-      return NO;
-    }
-    NSRange nonNewlineRange = [nonNewlineVal rangeValue];
-    if(NSEqualRanges(range, nonNewlineRange)) {
-      [TextInsertionUtils replaceText:text at:range additionalAttributes:nullptr input:_input withSelection:YES];
-      [self removeAttributes:NSMakeRange(range.location, 0)];
+    
+    if(NSEqualRanges(_input->textView.selectedRange, NSMakeRange(0, 0))) {
+      // a backspace on the very first input's line list point
+      // it doesn't run textVieDidChange so we need to manually remove attributes
+      [self removeAttributes:paragraphRange];
+      return YES;
+    } else if(range.location == paragraphRange.location - 1) {
+      // same case in other lines; here, the removed range location will be exactly 1 less than paragraph range location
+      [self removeAttributes:paragraphRange];
       return YES;
     }
   }

--- a/ios/utils/OccurenceUtils.mm
+++ b/ios/utils/OccurenceUtils.mm
@@ -47,7 +47,7 @@
     NSRange attrRange = NSMakeRange(0, 0);
     attrValue = [input->textView.textStorage attribute:key atIndex:index effectiveRange:&attrRange];
   }
-  return condition(attrValue, NSMakeRange(index, 0));
+  return condition(attrValue, detectionRange);
 }
 
 + (BOOL)detectMultiple

--- a/ios/utils/ParagraphAttributesUtils.mm
+++ b/ios/utils/ParagraphAttributesUtils.mm
@@ -1,5 +1,6 @@
 #import "ParagraphAttributesUtils.h"
 #import "EnrichedTextInputView.h"
+#import "StyleHeaders.h"
 #import "ParagraphsUtils.h"
 #import "TextInsertionUtils.h"
 
@@ -10,6 +11,10 @@
 // hence the solution - reset typing attributes
 + (BOOL)handleBackspaceInRange:(NSRange)range replacementText:(NSString *)text input:(id)input {
   EnrichedTextInputView *typedInput = (EnrichedTextInputView *)input;
+  UnorderedListStyle *ulStyle = typedInput->stylesDict[@([UnorderedListStyle getStyleType])];
+  OrderedListStyle *olStyle = typedInput->stylesDict[@([OrderedListStyle getStyleType])];
+  BlockQuoteStyle *bqStyle = typedInput->stylesDict[@([BlockQuoteStyle getStyleType])];
+  
   if(typedInput == nullptr) {
     return NO;
   }
@@ -21,6 +26,12 @@
   
   // find a non-newline range of the paragraph
   NSRange paragraphRange = [typedInput->textView.textStorage.string paragraphRangeForRange:range];
+  
+  // for lists and quotes we don't want that behavior; we want zero width spaces to appear there
+  if([ulStyle detectStyle:paragraphRange] || [olStyle detectStyle:paragraphRange] || [bqStyle detectStyle:paragraphRange]) {
+    return NO;
+  }
+  
   NSArray *paragraphs = [ParagraphsUtils getNonNewlineRangesIn:typedInput->textView range:paragraphRange];
   if(paragraphs.count == 0) {
     return NO;
@@ -28,7 +39,7 @@
   
   NSRange nonNewlineRange = [(NSValue *)paragraphs.firstObject rangeValue];
   
-  // if the backspace removes the whole content of a paragraph - do the thing
+  // if the backspace removes the whole content of a paragraph, we remove the typing attributes
   if(NSEqualRanges(nonNewlineRange, range)) {
     // do the replacement manually
     [TextInsertionUtils replaceText:text at:range additionalAttributes:nullptr input:typedInput withSelection:YES];


### PR DESCRIPTION
Previous PRs brought a bit of mayhem to lists and quotes on iOS in terms of their behavior consistency; 
- the added utils that removed styles when all characters of a line were removed messed with the fact that lines and quotes shouldn't do that. A zero width space should appear there. Added a check in these utils for these styles.
- after fixing the above, zero width spaces still didn't appear in the first line because empty input "reset attributes" check was running first. Changed their order.
-  cleaned up and fixed the logic for handling backspaces within lists. Now backspace that is visibly done on the list/quote marker only removes style, keeping the whole line intact
- also fixed one edge case to the above behavior, which resulted in the style being removed because the attributes magically weren't preserved