### PR TITLE
fix: editable on iOS

### DIFF
--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -423,7 +423,7 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
   }
   
   // editable
-  if(newViewProps.editable != oldViewProps.editable) {
+  if(newViewProps.editable != textView.editable) {
     textView.editable = newViewProps.editable;
   }
   


### PR DESCRIPTION
When `editable` is set to `false` in the very first render, this flag is actually never set to `false`. Meaning component is always editable