### PR TITLE
fix: measuring component size for inline and code blocks

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/spans/EnrichedCodeBlockSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/spans/EnrichedCodeBlockSpan.kt
@@ -5,15 +5,19 @@ import android.graphics.Paint
 import android.graphics.RectF
 import android.graphics.Typeface
 import android.text.TextPaint
-import android.text.style.CharacterStyle
 import android.text.style.LineBackgroundSpan
+import android.text.style.MetricAffectingSpan
 import com.swmansion.enriched.spans.interfaces.EnrichedBlockSpan
 import com.swmansion.enriched.styles.HtmlStyle
 
-class EnrichedCodeBlockSpan(private val htmlStyle: HtmlStyle) : CharacterStyle(), LineBackgroundSpan, EnrichedBlockSpan {
-  override fun updateDrawState(paint: TextPaint?) {
-    paint?.typeface = Typeface.MONOSPACE
-    paint?.color = htmlStyle.codeBlockColor
+class EnrichedCodeBlockSpan(private val htmlStyle: HtmlStyle) : MetricAffectingSpan(), LineBackgroundSpan, EnrichedBlockSpan {
+  override fun updateDrawState(paint: TextPaint) {
+    paint.typeface = Typeface.MONOSPACE
+    paint.color = htmlStyle.codeBlockColor
+  }
+
+  override fun updateMeasureState(paint: TextPaint) {
+    paint.typeface = Typeface.MONOSPACE
   }
 
   override fun drawBackground(

--- a/android/src/main/java/com/swmansion/enriched/spans/EnrichedInlineCodeSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/spans/EnrichedInlineCodeSpan.kt
@@ -2,15 +2,20 @@ package com.swmansion.enriched.spans
 
 import android.graphics.Typeface
 import android.text.TextPaint
-import android.text.style.BackgroundColorSpan
+import android.text.style.MetricAffectingSpan
 import com.swmansion.enriched.spans.interfaces.EnrichedInlineSpan
 import com.swmansion.enriched.styles.HtmlStyle
 
-class EnrichedInlineCodeSpan(private val htmlStyle: HtmlStyle) : BackgroundColorSpan(htmlStyle.inlineCodeBackgroundColor), EnrichedInlineSpan {
+class EnrichedInlineCodeSpan(private val htmlStyle: HtmlStyle) : MetricAffectingSpan(), EnrichedInlineSpan {
   override fun updateDrawState(textPaint: TextPaint) {
-    super.updateDrawState(textPaint)
-
+    val typeface = Typeface.create(Typeface.MONOSPACE, Typeface.NORMAL)
+    textPaint.typeface = typeface
     textPaint.color = htmlStyle.inlineCodeColor
-    textPaint.typeface = Typeface.create(Typeface.MONOSPACE, Typeface.NORMAL)
+    textPaint.bgColor = htmlStyle.inlineCodeBackgroundColor
+  }
+
+  override fun updateMeasureState(textPaint: TextPaint) {
+    val typeface = Typeface.create(Typeface.MONOSPACE, Typeface.NORMAL)
+    textPaint.typeface = typeface
   }
 }


### PR DESCRIPTION
Inline code and code block styles modifies typeface, meaning that this change counts for measuring layout using `StaticLayout`. We have to use proper base class (like `MetricAffectingSpan`) to calculate it properly 