### PR TITLE
fix: measuring layout for lists and blockquotes - android

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/spans/EnrichedBlockQuoteSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/spans/EnrichedBlockQuoteSpan.kt
@@ -4,13 +4,17 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.text.Layout
 import android.text.TextPaint
-import android.text.style.CharacterStyle
 import android.text.style.LeadingMarginSpan
+import android.text.style.MetricAffectingSpan
 import com.swmansion.enriched.spans.interfaces.EnrichedBlockSpan
 import com.swmansion.enriched.styles.HtmlStyle
 
 // https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/java/android/text/style/QuoteSpan.java
-class EnrichedBlockQuoteSpan(private val htmlStyle: HtmlStyle) : CharacterStyle(), LeadingMarginSpan, EnrichedBlockSpan {
+class EnrichedBlockQuoteSpan(private val htmlStyle: HtmlStyle) : MetricAffectingSpan(), LeadingMarginSpan, EnrichedBlockSpan {
+  override fun updateMeasureState(p0: TextPaint) {
+    // Do nothing, but inform layout that this span affects text metrics
+  }
+
   override fun getLeadingMargin(p0: Boolean): Int {
     return htmlStyle.blockquoteStripeWidth + htmlStyle.blockquoteGapWidth
   }

--- a/android/src/main/java/com/swmansion/enriched/spans/EnrichedOrderedListSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/spans/EnrichedOrderedListSpan.kt
@@ -4,11 +4,21 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Typeface
 import android.text.Layout
+import android.text.TextPaint
 import android.text.style.LeadingMarginSpan
+import android.text.style.MetricAffectingSpan
 import com.swmansion.enriched.spans.interfaces.EnrichedParagraphSpan
 import com.swmansion.enriched.styles.HtmlStyle
 
-class EnrichedOrderedListSpan(private var index: Int, private val htmlStyle: HtmlStyle) : LeadingMarginSpan, EnrichedParagraphSpan {
+class EnrichedOrderedListSpan(private var index: Int, private val htmlStyle: HtmlStyle) : MetricAffectingSpan(), LeadingMarginSpan, EnrichedParagraphSpan {
+  override fun updateMeasureState(p0: TextPaint) {
+    // Do nothing, but inform layout that this span affects text metrics
+  }
+
+  override fun updateDrawState(p0: TextPaint?) {
+    // Do nothing, but inform layout that this span affects text metrics
+  }
+
   override fun getLeadingMargin(first: Boolean): Int {
     return htmlStyle.olMarginLeft + htmlStyle.olGapWidth
   }

--- a/android/src/main/java/com/swmansion/enriched/spans/EnrichedUnorderedListSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/spans/EnrichedUnorderedListSpan.kt
@@ -4,12 +4,22 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.text.Layout
 import android.text.Spanned
+import android.text.TextPaint
 import android.text.style.LeadingMarginSpan
+import android.text.style.MetricAffectingSpan
 import com.swmansion.enriched.spans.interfaces.EnrichedParagraphSpan
 import com.swmansion.enriched.styles.HtmlStyle
 
 // https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/java/android/text/style/BulletSpan.java
-class EnrichedUnorderedListSpan(private val htmlStyle: HtmlStyle) : LeadingMarginSpan, EnrichedParagraphSpan {
+class EnrichedUnorderedListSpan(private val htmlStyle: HtmlStyle) : MetricAffectingSpan(), LeadingMarginSpan, EnrichedParagraphSpan {
+  override fun updateMeasureState(p0: TextPaint) {
+    // Do nothing, but inform layout that this span affects text metrics
+  }
+
+  override fun updateDrawState(p0: TextPaint?) {
+    // Do nothing, but inform layout that this span affects text metrics
+  }
+
   override fun getLeadingMargin(p0: Boolean): Int {
     return htmlStyle.ulBulletSize + htmlStyle.ulGapWidth + htmlStyle.ulMarginLeft
   }


### PR DESCRIPTION
Similar to https://github.com/software-mansion/react-native-enriched/pull/214, we have to explicitly inform static layout that those spans affects layout measurements