### PR TITLE
fix: text break strategy - layout calculation - android

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/EnrichedTextInputView.kt
+++ b/android/src/main/java/com/swmansion/enriched/EnrichedTextInputView.kt
@@ -7,6 +7,7 @@ import android.graphics.BlendMode
 import android.graphics.BlendModeColorFilter
 import android.graphics.Color
 import android.graphics.Rect
+import android.graphics.text.LineBreaker
 import android.os.Build
 import android.text.InputType
 import android.text.Spannable
@@ -101,6 +102,10 @@ class EnrichedTextInputView : AppCompatEditText {
     isVerticalScrollBarEnabled = true
     gravity = Gravity.TOP or Gravity.START
     inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      breakStrategy = LineBreaker.BREAK_STRATEGY_HIGH_QUALITY
+    }
 
     setPadding(0, 0, 0, 0)
     setBackgroundColor(Color.TRANSPARENT)

--- a/android/src/main/java/com/swmansion/enriched/EnrichedTextInputViewLayoutManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/EnrichedTextInputViewLayoutManager.kt
@@ -1,5 +1,7 @@
 package com.swmansion.enriched
 
+import android.graphics.text.LineBreaker
+import android.os.Build
 import android.text.Editable
 import android.text.StaticLayout
 import com.facebook.react.bridge.Arguments
@@ -50,12 +52,20 @@ class EnrichedTextInputViewLayoutManager(private val view: EnrichedTextInputView
     val paint = view.paint
     val textLength = text.length
 
-    val staticLayout = StaticLayout.Builder
+    val builder = StaticLayout.Builder
       .obtain(text, 0, textLength, paint, maxWidth.toInt())
       .setIncludePad(true)
       .setLineSpacing(0f, 1f)
-      .build()
 
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      builder.setBreakStrategy(LineBreaker.BREAK_STRATEGY_HIGH_QUALITY)
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      builder.setUseLineSpacingFromFallbacks(true)
+    }
+
+    val staticLayout = builder.build()
     val heightInSP = PixelUtil.toDIPFromPixel(staticLayout.height.toFloat())
     val widthInSP = PixelUtil.toDIPFromPixel(maxWidth)
 


### PR DESCRIPTION
Fixes issue when component height is calculated incorrectly because of text breaking behavior.
This PR ensures that breaking strategy used for displaying text and calculating height is consistent. Additionally, starting from now we use `BREAK_STRATEGY_HIGH_QUALITY` which is consistent with default React Native Android behavior

[Before](https://github.com/user-attachments/assets/df328108-e2a3-40c8-b8a8-66905662f827)

[After](https://github.com/user-attachments/assets/7ff84bc0-22d6-41ad-bf72-61f7642cbf41)