### PR TITLE
feat: simplify iOS events emitting blocking

### DIFF
--- a/example/ios/EnrichedTextInputExample.xcodeproj/project.pbxproj
+++ b/example/ios/EnrichedTextInputExample.xcodeproj/project.pbxproj
@@ -16,10 +16,10 @@
 		31EE7B79626043278451F7C2 /* Nunito-MediumItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 56DFDD6005684613BABE1A5B /* Nunito-MediumItalic.ttf */; };
 		44F3116C228D441D96648511 /* Nunito-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = DA817F04F35B4BA1A6C0BB7A /* Nunito-Bold.ttf */; };
 		475EC9D8C2514408931549DD /* Nunito-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 012D53DFD8C6464DBF6E19E4 /* Nunito-Black.ttf */; };
-		4B4950F65A47714993F53BB4 /* libPods-EnrichedTextInputExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 95CD629A5570EDEE67260A64 /* libPods-EnrichedTextInputExample.a */; };
 		4FEAEB180FF94632ADFA7D7D /* Nunito-SemiBoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 78A78FF825C747578571B76F /* Nunito-SemiBoldItalic.ttf */; };
 		56EDC86733EA478B9DA01878 /* CascadiaCode-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 87375222174145AD85B4DE62 /* CascadiaCode-Medium.ttf */; };
 		5B86D220CCF04C2A850EB7E8 /* CascadiaCode-MediumItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 78D6C09519344432B162E948 /* CascadiaCode-MediumItalic.ttf */; };
+		5BD1F645E224B050AB1B4335 /* libPods-EnrichedTextInputExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 729B8071725F28C255C87975 /* libPods-EnrichedTextInputExample.a */; };
 		6491322815F54E2A8CF781B9 /* Nunito-ExtraBoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B6D4F5AC2C5D41998A5643BB /* Nunito-ExtraBoldItalic.ttf */; };
 		71808E445FEA4FCF902169F4 /* CascadiaCode-Italic-VariableFont_wght.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 3A18DEB91C24449AA3ECE59A /* CascadiaCode-Italic-VariableFont_wght.ttf */; };
 		71AA7E56B3D7424AB82C5D46 /* CascadiaCode-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 79452663257A4B73B2308643 /* CascadiaCode-Bold.ttf */; };
@@ -58,7 +58,6 @@
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = EnrichedTextInputExample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		153B340F016F497BA045811A /* Nunito-Light.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-Light.ttf"; path = "../assets/fonts/Nunito/static/Nunito-Light.ttf"; sourceTree = "<group>"; };
 		1872D96B58594795BDF6C766 /* Nunito-ExtraLight.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-ExtraLight.ttf"; path = "../assets/fonts/Nunito/static/Nunito-ExtraLight.ttf"; sourceTree = "<group>"; };
-		371B368B6AB82CCE5511A1CA /* Pods-EnrichedTextInputExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EnrichedTextInputExample.debug.xcconfig"; path = "Target Support Files/Pods-EnrichedTextInputExample/Pods-EnrichedTextInputExample.debug.xcconfig"; sourceTree = "<group>"; };
 		375DF342F26841F6BF549CAB /* Nunito-SemiBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-SemiBold.ttf"; path = "../assets/fonts/Nunito/static/Nunito-SemiBold.ttf"; sourceTree = "<group>"; };
 		3A18DEB91C24449AA3ECE59A /* CascadiaCode-Italic-VariableFont_wght.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "CascadiaCode-Italic-VariableFont_wght.ttf"; path = "../assets/fonts/Cascadia_Code/CascadiaCode-Italic-VariableFont_wght.ttf"; sourceTree = "<group>"; };
 		3FD646A3FF0F4F33AC65021F /* CascadiaCode-SemiBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "CascadiaCode-SemiBold.ttf"; path = "../assets/fonts/Cascadia_Code/static/CascadiaCode-SemiBold.ttf"; sourceTree = "<group>"; };
@@ -66,13 +65,14 @@
 		4DA2D2AB9E3743888DAD5779 /* CascadiaCode-SemiBoldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "CascadiaCode-SemiBoldItalic.ttf"; path = "../assets/fonts/Cascadia_Code/static/CascadiaCode-SemiBoldItalic.ttf"; sourceTree = "<group>"; };
 		4E36300E55D4493B9BE898E6 /* CascadiaCode-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "CascadiaCode-Regular.ttf"; path = "../assets/fonts/Cascadia_Code/static/CascadiaCode-Regular.ttf"; sourceTree = "<group>"; };
 		50E0071425F54B07BF7B82D6 /* Nunito-BlackItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-BlackItalic.ttf"; path = "../assets/fonts/Nunito/static/Nunito-BlackItalic.ttf"; sourceTree = "<group>"; };
+		52C456987C8BDF13AA987EF4 /* Pods-EnrichedTextInputExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EnrichedTextInputExample.release.xcconfig"; path = "Target Support Files/Pods-EnrichedTextInputExample/Pods-EnrichedTextInputExample.release.xcconfig"; sourceTree = "<group>"; };
 		56DFDD6005684613BABE1A5B /* Nunito-MediumItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-MediumItalic.ttf"; path = "../assets/fonts/Nunito/static/Nunito-MediumItalic.ttf"; sourceTree = "<group>"; };
 		5D1BB596339A4F8E8CBC2087 /* CascadiaCode-BoldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "CascadiaCode-BoldItalic.ttf"; path = "../assets/fonts/Cascadia_Code/static/CascadiaCode-BoldItalic.ttf"; sourceTree = "<group>"; };
 		5D3162FFD8AA482CB6A0E084 /* Nunito-VariableFont_wght.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-VariableFont_wght.ttf"; path = "../assets/fonts/Nunito/Nunito-VariableFont_wght.ttf"; sourceTree = "<group>"; };
 		5D3228FB7E494D31805D6C01 /* Nunito-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-Regular.ttf"; path = "../assets/fonts/Nunito/static/Nunito-Regular.ttf"; sourceTree = "<group>"; };
 		6352E13F84F841D5A2BA25B4 /* CascadiaCode-Italic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "CascadiaCode-Italic.ttf"; path = "../assets/fonts/Cascadia_Code/static/CascadiaCode-Italic.ttf"; sourceTree = "<group>"; };
 		674C8E7598D647768ECEC0E1 /* OFL.txt */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = OFL.txt; path = ../assets/fonts/Cascadia_Code/OFL.txt; sourceTree = "<group>"; };
-		6918616D8394A3A8000BFE5C /* Pods-EnrichedTextInputExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EnrichedTextInputExample.release.xcconfig"; path = "Target Support Files/Pods-EnrichedTextInputExample/Pods-EnrichedTextInputExample.release.xcconfig"; sourceTree = "<group>"; };
+		729B8071725F28C255C87975 /* libPods-EnrichedTextInputExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EnrichedTextInputExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		761780EC2CA45674006654EE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = EnrichedTextInputExample/AppDelegate.swift; sourceTree = "<group>"; };
 		78A78FF825C747578571B76F /* Nunito-SemiBoldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-SemiBoldItalic.ttf"; path = "../assets/fonts/Nunito/static/Nunito-SemiBoldItalic.ttf"; sourceTree = "<group>"; };
 		78D6C09519344432B162E948 /* CascadiaCode-MediumItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "CascadiaCode-MediumItalic.ttf"; path = "../assets/fonts/Cascadia_Code/static/CascadiaCode-MediumItalic.ttf"; sourceTree = "<group>"; };
@@ -84,10 +84,10 @@
 		87375222174145AD85B4DE62 /* CascadiaCode-Medium.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "CascadiaCode-Medium.ttf"; path = "../assets/fonts/Cascadia_Code/static/CascadiaCode-Medium.ttf"; sourceTree = "<group>"; };
 		8A425B9B75B9488EA0FDF624 /* README.txt */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = README.txt; path = ../assets/fonts/Cascadia_Code/README.txt; sourceTree = "<group>"; };
 		8DDAE8E93F2D4651A22D1882 /* Nunito-LightItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-LightItalic.ttf"; path = "../assets/fonts/Nunito/static/Nunito-LightItalic.ttf"; sourceTree = "<group>"; };
-		95CD629A5570EDEE67260A64 /* libPods-EnrichedTextInputExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EnrichedTextInputExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		974D908628154101A0445B89 /* Nunito-Medium.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-Medium.ttf"; path = "../assets/fonts/Nunito/static/Nunito-Medium.ttf"; sourceTree = "<group>"; };
 		ABF6C071A9704D7F84EAC642 /* Nunito-Italic-VariableFont_wght.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-Italic-VariableFont_wght.ttf"; path = "../assets/fonts/Nunito/Nunito-Italic-VariableFont_wght.ttf"; sourceTree = "<group>"; };
 		AFECE93D073F484A93612569 /* Nunito-ExtraLightItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-ExtraLightItalic.ttf"; path = "../assets/fonts/Nunito/static/Nunito-ExtraLightItalic.ttf"; sourceTree = "<group>"; };
+		B07DE4D2676CF7CA922206C0 /* Pods-EnrichedTextInputExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EnrichedTextInputExample.debug.xcconfig"; path = "Target Support Files/Pods-EnrichedTextInputExample/Pods-EnrichedTextInputExample.debug.xcconfig"; sourceTree = "<group>"; };
 		B6CB34AFACC240079497790D /* Nunito-Italic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-Italic.ttf"; path = "../assets/fonts/Nunito/static/Nunito-Italic.ttf"; sourceTree = "<group>"; };
 		B6D4F5AC2C5D41998A5643BB /* Nunito-ExtraBoldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-ExtraBoldItalic.ttf"; path = "../assets/fonts/Nunito/static/Nunito-ExtraBoldItalic.ttf"; sourceTree = "<group>"; };
 		C667157990F34428AEE8CC93 /* FontAwesome.json */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome.json; path = ../assets/icons/FontAwesome.json; sourceTree = "<group>"; };
@@ -104,7 +104,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4B4950F65A47714993F53BB4 /* libPods-EnrichedTextInputExample.a in Frameworks */,
+				5BD1F645E224B050AB1B4335 /* libPods-EnrichedTextInputExample.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -127,7 +127,7 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				95CD629A5570EDEE67260A64 /* libPods-EnrichedTextInputExample.a */,
+				729B8071725F28C255C87975 /* libPods-EnrichedTextInputExample.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -165,8 +165,8 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				371B368B6AB82CCE5511A1CA /* Pods-EnrichedTextInputExample.debug.xcconfig */,
-				6918616D8394A3A8000BFE5C /* Pods-EnrichedTextInputExample.release.xcconfig */,
+				B07DE4D2676CF7CA922206C0 /* Pods-EnrichedTextInputExample.debug.xcconfig */,
+				52C456987C8BDF13AA987EF4 /* Pods-EnrichedTextInputExample.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -222,13 +222,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "EnrichedTextInputExample" */;
 			buildPhases = (
-				78C433C49BA99727B8F82093 /* [CP] Check Pods Manifest.lock */,
+				AA3F849D431650759A5C2B07 /* [CP] Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				EDDF48CF048F8E3AEC92FBE1 /* [CP] Embed Pods Frameworks */,
-				F803EE48F3DE8A3C8C2D3B60 /* [CP] Copy Pods Resources */,
+				5CE6966A05AD974174E7B317 /* [CP] Embed Pods Frameworks */,
+				20D9256BDA812B9B281771D2 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -336,7 +336,41 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		78C433C49BA99727B8F82093 /* [CP] Check Pods Manifest.lock */ = {
+		20D9256BDA812B9B281771D2 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-EnrichedTextInputExample/Pods-EnrichedTextInputExample-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-EnrichedTextInputExample/Pods-EnrichedTextInputExample-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-EnrichedTextInputExample/Pods-EnrichedTextInputExample-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5CE6966A05AD974174E7B317 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-EnrichedTextInputExample/Pods-EnrichedTextInputExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-EnrichedTextInputExample/Pods-EnrichedTextInputExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-EnrichedTextInputExample/Pods-EnrichedTextInputExample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		AA3F849D431650759A5C2B07 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -358,40 +392,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		EDDF48CF048F8E3AEC92FBE1 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-EnrichedTextInputExample/Pods-EnrichedTextInputExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-EnrichedTextInputExample/Pods-EnrichedTextInputExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-EnrichedTextInputExample/Pods-EnrichedTextInputExample-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F803EE48F3DE8A3C8C2D3B60 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-EnrichedTextInputExample/Pods-EnrichedTextInputExample-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-EnrichedTextInputExample/Pods-EnrichedTextInputExample-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-EnrichedTextInputExample/Pods-EnrichedTextInputExample-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -408,7 +408,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 371B368B6AB82CCE5511A1CA /* Pods-EnrichedTextInputExample.debug.xcconfig */;
+			baseConfigurationReference = B07DE4D2676CF7CA922206C0 /* Pods-EnrichedTextInputExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -436,7 +436,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6918616D8394A3A8000BFE5C /* Pods-EnrichedTextInputExample.release.xcconfig */;
+			baseConfigurationReference = 52C456987C8BDF13AA987EF4 /* Pods-EnrichedTextInputExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/ios/EnrichedTextInputView.h
+++ b/ios/EnrichedTextInputView.h
@@ -19,7 +19,6 @@ NS_ASSUME_NONNULL_BEGIN
   @public NSMutableDictionary<NSAttributedStringKey, id> *defaultTypingAttributes;
   @public NSDictionary<NSNumber *, id<BaseStyleProtocol>> *stylesDict;
   @public BOOL blockEmitting;
-  @public BOOL emitHtml;
 }
 - (CGSize)measureSize:(CGFloat)maxWidth;
 - (void)emitOnLinkDetectedEvent:(NSString *)text url:(NSString *)url range:(NSRange)range;

--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -34,6 +34,7 @@ using namespace facebook::react;
   MentionParams *_recentlyActiveMentionParams;
   NSRange _recentlyActiveMentionRange;
   NSString *_recentlyEmittedHtml;
+  BOOL _emitHtml;
   UILabel *_placeholderLabel;
   UIColor *_placeholderColor;
   BOOL _emitFocusBlur;
@@ -75,7 +76,7 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
   recentlyChangedRange = NSMakeRange(0, 0);
   _recentlyEmittedString = @"";
   _recentlyEmittedHtml = @"";
-  emitHtml = NO;
+  _emitHtml = NO;
   blockEmitting = NO;
   _emitFocusBlur = YES;
   
@@ -393,22 +394,17 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
     
     // now set the new config
     config = newConfig;
-    
-    // we don't want to emit these html changes in here
-    BOOL prevEmitHtml = emitHtml;
-    if(prevEmitHtml) {
-      emitHtml = NO;
-    }
-    
+        
+    // no emitting during styles reload
+    blockEmitting = YES;
+        
     // make sure everything is sound in the html
     NSString *initiallyProcessedHtml = [parser initiallyProcessHtml:currentHtml];
     if(initiallyProcessedHtml != nullptr) {
       [parser replaceWholeFromHtml:initiallyProcessedHtml];
     }
     
-    if(prevEmitHtml) {
-      emitHtml = YES;
-    }
+    blockEmitting = NO;
     
     // fill the typing attributes with style props
     defaultTypingAttributes[NSForegroundColorAttributeName] = [config primaryColor];
@@ -509,7 +505,7 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
   }
   
   // isOnChangeHtmlSet
-  emitHtml = newViewProps.isOnChangeHtmlSet;
+  _emitHtml = newViewProps.isOnChangeHtmlSet;
   
   [super updateProps:props oldProps:oldProps];
   // mandatory text and height checks
@@ -846,7 +842,7 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
 }
 
 - (void)tryEmittingOnChangeHtmlEvent {
-  if(!emitHtml || textView.markedTextRange != nullptr) {
+  if(!_emitHtml || textView.markedTextRange != nullptr) {
     return;
   }
   auto emitter = [self getEventEmitter];

--- a/ios/styles/OrderedListStyle.mm
+++ b/ios/styles/OrderedListStyle.mm
@@ -158,18 +158,13 @@
     if(charBefore == '1') {
       // we got a match - add a list if possible
       if([_input handleStyleBlocksAndConflicts:[[self class] getStyleType] range:paragraphRange]) {
-        // don't emit some html updates during the replacing
-        BOOL prevEmitHtml = _input->emitHtml;
-        if(prevEmitHtml) {
-          _input->emitHtml = NO;
-        }
+        // don't emit during the replacing
+        _input->blockEmitting = YES;
         
         // remove the number
         [TextInsertionUtils replaceText:@"" at:NSMakeRange(paragraphRange.location, 1) additionalAttributes:nullptr input:_input withSelection:YES];
         
-        if(prevEmitHtml) {
-          _input->emitHtml = YES;
-        }
+        _input->blockEmitting = NO;
         
         // add attributes on the paragraph
         [self addAttributes:NSMakeRange(paragraphRange.location, paragraphRange.length - 1)];

--- a/ios/styles/UnorderedListStyle.mm
+++ b/ios/styles/UnorderedListStyle.mm
@@ -158,18 +158,13 @@
     if(charBefore == '-') {
       // we got a match - add a list if possible
       if([_input handleStyleBlocksAndConflicts:[[self class] getStyleType] range:paragraphRange]) {
-        // don't emit some html updates during the replacing
-        BOOL prevEmitHtml = _input->emitHtml;
-        if(prevEmitHtml) {
-          _input->emitHtml = NO;
-        }
+        // don't emit during the replacing
+        _input->blockEmitting = YES;
         
         // remove the dash
         [TextInsertionUtils replaceText:@"" at:NSMakeRange(paragraphRange.location, 1) additionalAttributes:nullptr input:_input withSelection:YES];
         
-        if(prevEmitHtml) {
-          _input->emitHtml = YES;
-        }
+        _input->blockEmitting = NO;
         
         // add attributes on the dashless paragraph
         [self addAttributes:NSMakeRange(paragraphRange.location, paragraphRange.length - 1)];


### PR DESCRIPTION
`emitHtml` was overused. Now it is there only to block html emitting when `onChangeHtml` event is not set on iOS. All the places it was handled for blocking could easily be swapped with the usage of `blockEmitting` flag that completely cuts off `eventEmitter`.