### PR TITLE
fix: handle style conflicts during automatic links detection

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/styles/ParametrizedStyles.kt
+++ b/android/src/main/java/com/swmansion/enriched/styles/ParametrizedStyles.kt
@@ -104,29 +104,26 @@ class ParametrizedStyles(private val view: EnrichedTextInputView) {
     return Triple(result, start, end)
   }
 
-  private fun detectLinkConflicts(): Boolean {
-    val mergingConfig = EnrichedSpans.getMergingConfigForStyle(EnrichedSpans.LINK, view.htmlStyle)?: return false
+  private fun canLinkBeApplied(): Boolean {
+    val mergingConfig = EnrichedSpans.getMergingConfigForStyle(EnrichedSpans.LINK, view.htmlStyle)?: return true
     val conflictingStyles = mergingConfig.conflictingStyles
     val blockingStyles = mergingConfig.blockingStyles
 
     for (style in blockingStyles) {
-      if (view.spanState?.getStart(style) != null) return true
+      if (view.spanState?.getStart(style) != null) return false
     }
 
     for (style in conflictingStyles) {
-      if (view.spanState?.getStart(style) != null) return true
+      if (view.spanState?.getStart(style) != null) return false
     }
 
-    return false
+    return true
   }
 
   private fun afterTextChangedLinks(result: Triple<String, Int, Int>) {
-    if (detectLinkConflicts()) {
-      return
-    }
-
     // Do not detect link if it's applied manually
-    if (isSettingLinkSpan) return
+    if (isSettingLinkSpan || !canLinkBeApplied()) return
+
     val spannable = view.text as Spannable
     val (word, start, end) = result
 


### PR DESCRIPTION
# Summary
Fixes: #256 

Previously, links that were automatically detected from typed text could still receive link styles even in areas where link styling should be restricted (e.g. inside a code block).

This PR fixes that, making the behavior consistent with manual link application:
- Adds a new helper function `detectLinkConflicts` that checks whether the selected range contains blocking or conflicting styles.
- Updates `afterTextChangedLinks` to skip applying auto-detected links if any conflicts are detected.

## Test Plan

1. Go to Example app
2. Create codeblock
3. Type example.com inside codeblock

## Screenshots / Videos

https://github.com/user-attachments/assets/d1e66dec-527e-4bd5-adce-e1db2f2867ba


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
