### PR TITLE
feat: make <a> tags with no href or empty href not treated as links

### DIFF
--- a/ios/inputParser/InputParser.mm
+++ b/ios/inputParser/InputParser.mm
@@ -623,6 +623,7 @@
       
       NSRange hrefRange = match.range;
       [styleArr addObject:@([LinkStyle getStyleType])];
+      // cut only the url from the href="..." string
       NSString *url = [params substringWithRange:NSMakeRange(hrefRange.location + 6, hrefRange.length - 7)];
       stylePair.styleValue = url;
     } else if([tagName isEqualToString:@"mention"]) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR is an alternative to other PR in here handling iOS crashes due to `<a>` tag not having `href` attribute. While the other on e decides to allow empty `hrefs` as proper links, Android has no such logic. We discussed it a bit with @exploIF and are more eager to go the following way;
- No `href` attribute or an empty one => `<a>` tag not treated as a a link

## Test Plan

- Open iOS example app
- Input following html either into `Set input's value` field or into the component's `defaultValue` prop in `App.tsx`;
```
<html>
<p><a href="xd.com">Test2xdd</a></p>
</html>
```
Should be nicely treated as a link. Now make the href empty or completely remove the attribute from the tag. It should not be treated as a link and a new html won't have an `<a>` tag in there anymore.

## Screenshots / Videos

--

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅ (already handled that way)     |
