### PR TITLE
feat: add foreground color style

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/EnrichedTextInputView.kt
+++ b/android/src/main/java/com/swmansion/enriched/EnrichedTextInputView.kt
@@ -691,6 +691,15 @@ class EnrichedTextInputView : AppCompatEditText {
     dispatcher?.dispatchEvent(OnRequestHtmlResultEvent(surfaceId, id, requestId, html, experimentalSynchronousEvents))
   }
 
+  fun setColor(color: Int) {
+    val isValid = verifyStyle(EnrichedSpans.COLOR)
+    if (!isValid) return
+
+    inlineStyles?.setColorStyle(color)
+  }
+
+  fun removeColor() = inlineStyles?.removeColorSpan()
+
   // Sometimes setting up style triggers many changes in sequence
   // Eg. removing conflicting styles -> changing text -> applying spans
   // In such scenario we want to prevent from handling side effects (eg. onTextChanged)

--- a/android/src/main/java/com/swmansion/enriched/EnrichedTextInputViewManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/EnrichedTextInputViewManager.kt
@@ -338,13 +338,11 @@ class EnrichedTextInputViewManager :
     view?.verifyAndToggleStyle(EnrichedSpans.UNORDERED_LIST)
   }
 
-  override fun addLink(
-    view: EnrichedTextInputView?,
-    start: Int,
-    end: Int,
-    text: String,
-    url: String,
-  ) {
+  override fun toggleColor(view: EnrichedTextInputView?, color: String) {
+    // no-op for now
+  }
+
+  override fun addLink(view: EnrichedTextInputView?, start: Int, end: Int, text: String, url: String) {
     view?.addLink(start, end, text, url)
   }
 

--- a/android/src/main/java/com/swmansion/enriched/EnrichedTextInputViewManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/EnrichedTextInputViewManager.kt
@@ -338,7 +338,11 @@ class EnrichedTextInputViewManager :
     view?.verifyAndToggleStyle(EnrichedSpans.UNORDERED_LIST)
   }
 
-  override fun toggleColor(view: EnrichedTextInputView?, color: String) {
+  override fun setColor(view: EnrichedTextInputView?, color: String) {
+    // no-op for now
+  }
+
+  override fun removeColor(view: EnrichedTextInputView?) {
     // no-op for now
   }
 

--- a/android/src/main/java/com/swmansion/enriched/EnrichedTextInputViewManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/EnrichedTextInputViewManager.kt
@@ -1,6 +1,7 @@
 package com.swmansion.enriched
 
 import android.content.Context
+import androidx.core.graphics.toColorInt
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.module.annotations.ReactModule
@@ -338,15 +339,24 @@ class EnrichedTextInputViewManager :
     view?.verifyAndToggleStyle(EnrichedSpans.UNORDERED_LIST)
   }
 
-  override fun setColor(view: EnrichedTextInputView?, color: String) {
-    // no-op for now
+  override fun setColor(
+    view: EnrichedTextInputView?,
+    color: String,
+  ) {
+    view?.setColor(color.toColorInt())
   }
 
   override fun removeColor(view: EnrichedTextInputView?) {
-    // no-op for now
+    view?.removeColor()
   }
 
-  override fun addLink(view: EnrichedTextInputView?, start: Int, end: Int, text: String, url: String) {
+  override fun addLink(
+    view: EnrichedTextInputView?,
+    start: Int,
+    end: Int,
+    text: String,
+    url: String,
+  ) {
     view?.addLink(start, end, text, url)
   }
 

--- a/android/src/main/java/com/swmansion/enriched/events/OnColorChangeEvent.kt
+++ b/android/src/main/java/com/swmansion/enriched/events/OnColorChangeEvent.kt
@@ -1,0 +1,28 @@
+package com.swmansion.enriched.events
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+
+class OnColorChangeEvent(
+  surfaceId: Int,
+  viewId: Int,
+  private val experimentalSynchronousEvents: Boolean,
+  private val color: String?,
+) : Event<OnColorChangeEvent>(surfaceId, viewId) {
+  override fun getEventName(): String = EVENT_NAME
+
+  override fun getEventData(): WritableMap {
+    val eventData: WritableMap = Arguments.createMap()
+
+    eventData.putString("color", color)
+
+    return eventData
+  }
+
+  override fun experimental_isSynchronous(): Boolean = experimentalSynchronousEvents
+
+  companion object {
+    const val EVENT_NAME: String = "onColorChangeInSelection"
+  }
+}

--- a/android/src/main/java/com/swmansion/enriched/spans/EnrichedColoredSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/spans/EnrichedColoredSpan.kt
@@ -1,0 +1,20 @@
+package com.swmansion.enriched.spans
+
+import android.text.style.ForegroundColorSpan
+import com.swmansion.enriched.spans.interfaces.EnrichedInlineSpan
+import com.swmansion.enriched.styles.HtmlStyle
+
+class EnrichedColoredSpan(
+  htmlStyle: HtmlStyle,
+  val color: Int,
+) : ForegroundColorSpan(color),
+  EnrichedInlineSpan {
+  override val dependsOnHtmlStyle: Boolean = false
+
+  override fun rebuildWithStyle(htmlStyle: HtmlStyle): EnrichedColoredSpan = EnrichedColoredSpan(htmlStyle, color)
+
+  fun getHexColor(): String {
+    val rgb = foregroundColor and 0x00FFFFFF
+    return String.format("#%06X", rgb)
+  }
+}

--- a/android/src/main/java/com/swmansion/enriched/spans/EnrichedSpans.kt
+++ b/android/src/main/java/com/swmansion/enriched/spans/EnrichedSpans.kt
@@ -34,6 +34,7 @@ object EnrichedSpans {
   const val UNDERLINE = "underline"
   const val STRIKETHROUGH = "strikethrough"
   const val INLINE_CODE = "inline_code"
+  const val COLOR = "color"
 
   // paragraph styles
   const val H1 = "h1"
@@ -61,6 +62,7 @@ object EnrichedSpans {
       UNDERLINE to BaseSpanConfig(EnrichedUnderlineSpan::class.java),
       STRIKETHROUGH to BaseSpanConfig(EnrichedStrikeThroughSpan::class.java),
       INLINE_CODE to BaseSpanConfig(EnrichedInlineCodeSpan::class.java),
+      COLOR to BaseSpanConfig(EnrichedColoredSpan::class.java),
     )
 
   val paragraphSpans: Map<String, ParagraphSpanConfig> =
@@ -104,6 +106,13 @@ object EnrichedSpans {
         if (htmlStyle.h5Bold) blockingStyles.add(H5)
         if (htmlStyle.h6Bold) blockingStyles.add(H6)
         StylesMergingConfig(blockingStyles = blockingStyles.toTypedArray())
+      }
+
+      COLOR -> {
+        StylesMergingConfig(
+          conflictingStyles = arrayOf(INLINE_CODE),
+          blockingStyles = arrayOf(CODE_BLOCK, MENTION),
+        )
       }
 
       ITALIC -> {

--- a/android/src/main/java/com/swmansion/enriched/utils/EnrichedSelection.kt
+++ b/android/src/main/java/com/swmansion/enriched/utils/EnrichedSelection.kt
@@ -8,6 +8,7 @@ import com.swmansion.enriched.EnrichedTextInputView
 import com.swmansion.enriched.events.OnChangeSelectionEvent
 import com.swmansion.enriched.events.OnLinkDetectedEvent
 import com.swmansion.enriched.events.OnMentionDetectedEvent
+import com.swmansion.enriched.spans.EnrichedColoredSpan
 import com.swmansion.enriched.spans.EnrichedLinkSpan
 import com.swmansion.enriched.spans.EnrichedMentionSpan
 import com.swmansion.enriched.spans.EnrichedSpans
@@ -125,6 +126,9 @@ class EnrichedSelection(
       if (start == end && start == spanStart) {
         styleStart = null
       } else if (start >= spanStart && end <= spanEnd) {
+        if (span is EnrichedColoredSpan) {
+          view.spanState?.setTypingColor(span.color)
+        }
         styleStart = spanStart
       }
     }

--- a/android/src/main/java/com/swmansion/enriched/utils/EnrichedSpanState.kt
+++ b/android/src/main/java/com/swmansion/enriched/utils/EnrichedSpanState.kt
@@ -311,6 +311,7 @@ class EnrichedSpanState(
     val activeStyles =
       listOfNotNull(
         if (boldStart != null) EnrichedSpans.BOLD else null,
+        if (colorStart != null) EnrichedSpans.COLOR else null,
         if (italicStart != null) EnrichedSpans.ITALIC else null,
         if (underlineStart != null) EnrichedSpans.UNDERLINE else null,
         if (strikethroughStart != null) EnrichedSpans.STRIKETHROUGH else null,

--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -27,7 +27,7 @@ import {
   prepareImageDimensions,
 } from './utils/prepareImageDimensions';
 import type { OnChangeColorEvent } from '../../src/EnrichedTextInputNativeComponent';
-import ColorPreview from './components/ColorPreview';
+import { ColorPreview } from './components/ColorPreview';
 
 type StylesState = OnChangeStateEvent;
 
@@ -305,6 +305,10 @@ export default function App() {
     }
   };
 
+  const handleRemoveColor = () => {
+    ref.current?.removeColor();
+  };
+
   return (
     <>
       <ScrollView
@@ -355,6 +359,11 @@ export default function App() {
         <Button
           title="Set input's value"
           onPress={openValueModal}
+          style={styles.valueButton}
+        />
+        <Button
+          title="Remove color"
+          onPress={handleRemoveColor}
           style={styles.valueButton}
         />
         <HtmlSection currentHtml={currentHtml} />

--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -9,6 +9,7 @@ import {
   type OnChangeStateEvent,
   type OnChangeSelectionEvent,
   type HtmlStyle,
+  type OnChangeColorEvent,
 } from 'react-native-enriched';
 import { useRef, useState } from 'react';
 import { Button } from './components/Button';
@@ -26,7 +27,6 @@ import {
   DEFAULT_IMAGE_WIDTH,
   prepareImageDimensions,
 } from './utils/prepareImageDimensions';
-import type { OnChangeColorEvent } from '../../src/EnrichedTextInputNativeComponent';
 import { ColorPreview } from './components/ColorPreview';
 
 type StylesState = OnChangeStateEvent;
@@ -297,12 +297,8 @@ export default function App() {
     setSelection(sel);
   };
 
-  const handleSelectionColorChange = (
-    e: NativeSyntheticEvent<OnChangeColorEvent>
-  ) => {
-    if (e.nativeEvent.color) {
-      setSelectionColor(e.nativeEvent.color);
-    }
+  const handleSelectionColorChange = (e: OnChangeColorEvent) => {
+    setSelectionColor(e.color);
   };
 
   const handleRemoveColor = () => {
@@ -331,7 +327,9 @@ export default function App() {
             onChangeText={(e) => handleChangeText(e.nativeEvent)}
             onChangeHtml={(e) => handleChangeHtml(e.nativeEvent)}
             onChangeState={(e) => handleChangeState(e.nativeEvent)}
-            onColorChangeInSelection={handleSelectionColorChange}
+            onColorChangeInSelection={(e) =>
+              handleSelectionColorChange(e.nativeEvent)
+            }
             onLinkDetected={handleLinkDetected}
             onMentionDetected={console.log}
             onStartMention={handleStartMention}

--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -67,6 +67,8 @@ const DEFAULT_STYLES: StylesState = {
   mention: DEFAULT_STYLE_STATE,
 };
 
+const PRIMARY_COLOR = '#000000';
+
 const DEFAULT_LINK_STATE = {
   text: '',
   url: '',
@@ -514,6 +516,7 @@ const styles = StyleSheet.create({
     fontFamily: 'Nunito-Regular',
     paddingVertical: 12,
     paddingHorizontal: 14,
+    color: PRIMARY_COLOR,
   },
   scrollPlaceholder: {
     marginTop: 24,

--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -26,6 +26,8 @@ import {
   DEFAULT_IMAGE_WIDTH,
   prepareImageDimensions,
 } from './utils/prepareImageDimensions';
+import type { OnChangeColorEvent } from '../../src/EnrichedTextInputNativeComponent';
+import ColorPreview from './components/ColorPreview';
 
 type StylesState = OnChangeStateEvent;
 
@@ -45,6 +47,7 @@ const DEFAULT_STYLE_STATE = {
 
 const DEFAULT_STYLES: StylesState = {
   bold: DEFAULT_STYLE_STATE,
+  colored: DEFAULT_STYLE_STATE,
   italic: DEFAULT_STYLE_STATE,
   underline: DEFAULT_STYLE_STATE,
   strikeThrough: DEFAULT_STYLE_STATE,
@@ -94,6 +97,7 @@ export default function App() {
   const [stylesState, setStylesState] = useState<StylesState>(DEFAULT_STYLES);
   const [currentLink, setCurrentLink] =
     useState<CurrentLinkState>(DEFAULT_LINK_STATE);
+  const [selectionColor, setSelectionColor] = useState<string>(PRIMARY_COLOR);
 
   const ref = useRef<EnrichedTextInputInstance>(null);
 
@@ -293,6 +297,14 @@ export default function App() {
     setSelection(sel);
   };
 
+  const handleSelectionColorChange = (
+    e: NativeSyntheticEvent<OnChangeColorEvent>
+  ) => {
+    if (e.nativeEvent.color) {
+      setSelectionColor(e.nativeEvent.color);
+    }
+  };
+
   return (
     <>
       <ScrollView
@@ -315,6 +327,7 @@ export default function App() {
             onChangeText={(e) => handleChangeText(e.nativeEvent)}
             onChangeHtml={(e) => handleChangeHtml(e.nativeEvent)}
             onChangeState={(e) => handleChangeState(e.nativeEvent)}
+            onColorChangeInSelection={handleSelectionColorChange}
             onLinkDetected={handleLinkDetected}
             onMentionDetected={console.log}
             onStartMention={handleStartMention}
@@ -330,6 +343,7 @@ export default function App() {
           <Toolbar
             stylesState={stylesState}
             editorRef={ref}
+            selectionColor={selectionColor}
             onOpenLinkModal={openLinkModal}
             onSelectImage={openImageModal}
           />
@@ -345,6 +359,7 @@ export default function App() {
         />
         <HtmlSection currentHtml={currentHtml} />
         {DEBUG_SCROLLABLE && <View style={styles.scrollPlaceholder} />}
+        <ColorPreview color={selectionColor} />
       </ScrollView>
       <LinkModal
         isOpen={isLinkModalOpen}
@@ -422,7 +437,7 @@ const htmlStyle: HtmlStyle = {
     backgroundColor: 'yellow',
   },
   a: {
-    color: 'green',
+    color: 'blue',
     textDecorationLine: 'underline',
   },
   mention: {

--- a/apps/example/src/components/ColorPreview.tsx
+++ b/apps/example/src/components/ColorPreview.tsx
@@ -1,0 +1,32 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+type Props = {
+  color: string;
+};
+
+const ColorPreview: React.FC<Props> = ({ color }) => {
+  return (
+    <>
+      <View
+        style={[
+          styles.preview,
+          {
+            backgroundColor: color,
+          },
+        ]}
+      />
+      <Text>{color}</Text>
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  preview: {
+    marginVertical: 8,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+  },
+});
+
+export default ColorPreview;

--- a/apps/example/src/components/ColorPreview.tsx
+++ b/apps/example/src/components/ColorPreview.tsx
@@ -1,10 +1,11 @@
 import { StyleSheet, Text, View } from 'react-native';
+import { type FC } from 'react';
 
 type Props = {
   color: string;
 };
 
-const ColorPreview: React.FC<Props> = ({ color }) => {
+export const ColorPreview: FC<Props> = ({ color }) => {
   return (
     <>
       <View
@@ -28,5 +29,3 @@ const styles = StyleSheet.create({
     borderRadius: 20,
   },
 });
-
-export default ColorPreview;

--- a/apps/example/src/components/Toolbar.tsx
+++ b/apps/example/src/components/Toolbar.tsx
@@ -216,7 +216,7 @@ export const Toolbar: FC<ToolbarProps> = ({
   };
 
   const handleColorButtonPress = (color: string) => {
-    editorRef?.current?.toggleColor(color);
+    editorRef?.current?.setColor(color);
   };
 
   const isActive = (item: Item) => {

--- a/apps/example/src/components/Toolbar.tsx
+++ b/apps/example/src/components/Toolbar.tsx
@@ -5,6 +5,7 @@ import type {
   EnrichedTextInputInstance,
 } from 'react-native-enriched';
 import type { FC } from 'react';
+import { ToolbarColorButton } from './ToolbarColorButton';
 
 const STYLE_ITEMS = [
   {
@@ -79,6 +80,16 @@ const STYLE_ITEMS = [
     name: 'ordered-list',
     icon: 'list-ol',
   },
+  {
+    name: 'color',
+    value: '#FF0000',
+    text: 'A',
+  },
+  {
+    name: 'color',
+    value: '#E6FF5C',
+    text: 'A',
+  },
 ] as const;
 
 type Item = (typeof STYLE_ITEMS)[number];
@@ -89,6 +100,7 @@ export interface ToolbarProps {
   editorRef?: React.RefObject<EnrichedTextInputInstance | null>;
   onOpenLinkModal: () => void;
   onSelectImage: () => void;
+  selectionColor: string | null;
 }
 
 export const Toolbar: FC<ToolbarProps> = ({
@@ -96,6 +108,7 @@ export const Toolbar: FC<ToolbarProps> = ({
   editorRef,
   onOpenLinkModal,
   onSelectImage,
+  selectionColor,
 }) => {
   const handlePress = (item: Item) => {
     const currentRef = editorRef?.current;
@@ -202,6 +215,10 @@ export const Toolbar: FC<ToolbarProps> = ({
     }
   };
 
+  const handleColorButtonPress = (color: string) => {
+    editorRef?.current?.toggleColor(color);
+  };
+
   const isActive = (item: Item) => {
     switch (item.name) {
       case 'bold':
@@ -246,7 +263,14 @@ export const Toolbar: FC<ToolbarProps> = ({
   };
 
   const renderItem = ({ item }: ListRenderItemInfo<Item>) => {
-    return (
+    return item.name === 'color' ? (
+      <ToolbarColorButton
+        onPress={handleColorButtonPress}
+        color={item.value}
+        text={item.text}
+        isActive={stylesState.colored.isActive && selectionColor === item.value}
+      />
+    ) : (
       <ToolbarButton
         {...item}
         isActive={isActive(item)}
@@ -256,7 +280,8 @@ export const Toolbar: FC<ToolbarProps> = ({
     );
   };
 
-  const keyExtractor = (item: Item) => item.name;
+  const keyExtractor = (item: Item) =>
+    item.name === 'color' ? item.value : item.name;
 
   return (
     <FlatList

--- a/apps/example/src/components/ToolbarColorButton.tsx
+++ b/apps/example/src/components/ToolbarColorButton.tsx
@@ -1,0 +1,47 @@
+import { useMemo, type FC } from 'react';
+import { Pressable, StyleSheet, Text } from 'react-native';
+
+interface ColorButtonProps {
+  text: string;
+  isActive: boolean;
+  onPress: (color: string) => void;
+  color: string;
+}
+
+export const ToolbarColorButton: FC<ColorButtonProps> = ({
+  text,
+  isActive,
+  onPress,
+  color,
+}) => {
+  const handlePress = () => {
+    onPress(color);
+  };
+
+  const containerStyle = useMemo(
+    () => [
+      styles.container,
+      { backgroundColor: isActive ? color : 'rgba(0, 26, 114, 0.8)' },
+    ],
+    [isActive, color]
+  );
+
+  return (
+    <Pressable style={containerStyle} onPress={handlePress}>
+      <Text style={[styles.text, !isActive && { color }]}>{text}</Text>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: 56,
+    height: 56,
+  },
+  text: {
+    color: 'white',
+    fontSize: 20,
+  },
+});

--- a/apps/example/src/components/ToolbarColorButton.tsx
+++ b/apps/example/src/components/ToolbarColorButton.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type FC } from 'react';
+import { type FC } from 'react';
 import { Pressable, StyleSheet, Text } from 'react-native';
 
 interface ColorButtonProps {
@@ -18,16 +18,14 @@ export const ToolbarColorButton: FC<ColorButtonProps> = ({
     onPress(color);
   };
 
-  const containerStyle = useMemo(
-    () => [
-      styles.container,
-      { backgroundColor: isActive ? color : 'rgba(0, 26, 114, 0.8)' },
-    ],
-    [isActive, color]
-  );
-
   return (
-    <Pressable style={containerStyle} onPress={handlePress}>
+    <Pressable
+      style={[
+        styles.container,
+        { backgroundColor: isActive ? color : 'rgba(0, 26, 114, 0.8)' },
+      ]}
+      onPress={handlePress}
+    >
       <Text style={[styles.text, !isActive && { color }]}>{text}</Text>
     </Pressable>
   );

--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -1412,7 +1412,7 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
 
 - (void)removeColor {
   ColorStyle *colorStyle = stylesDict[@(Colored)];
-  [colorStyle removeAttributes: textView.selectedRange];
+  [colorStyle removeColorInSelectedRange];
   [self anyTextMayHaveBeenModified];
 }
 

--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -1158,10 +1158,13 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
     [self toggleRegularStyle: [UnderlineStyle getStyleType]];
   } else if([commandName isEqualToString:@"toggleStrikeThrough"]) {
     [self toggleRegularStyle: [StrikethroughStyle getStyleType]];
-  } else if([commandName isEqualToString:@"toggleColor"]) {
+  } else if([commandName isEqualToString:@"setColor"]) {
     NSString *colorText = (NSString *)args[0];
     UIColor *color = [UIColor colorFromString: colorText];
-    [self toggleColorStyle: color];
+    [self setColor: color];
+  } else if ([commandName isEqualToString:@"removeColor"]) {
+    ColorStyle *colorStyle = stylesDict[@([ColorStyle getStyleType])];
+    [colorStyle removeAttributes: textView.selectedRange];
   } else if([commandName isEqualToString:@"toggleInlineCode"]) {
     [self toggleRegularStyle: [InlineCodeStyle getStyleType]];
   } else if([commandName isEqualToString:@"addLink"]) {
@@ -1401,7 +1404,7 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
 
 // MARK: - Styles manipulation
 
-- (void)toggleColorStyle:(UIColor *)color {
+- (void)setColor:(UIColor *)color {
   ColorStyle *colorStyle = stylesDict[@(Colored)];
   
   [colorStyle applyStyle:textView.selectedRange color: color];

--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -1034,35 +1034,27 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
       _blockedStyles = newBlockedStyles;
 
       emitter->onChangeStateDeprecated({
-        .isBold = [_activeStyles containsObject:@([BoldStyle getStyleType])],
-        .isItalic =
-            [_activeStyles containsObject:@([ItalicStyle getStyleType])],
-        .isUnderline =
-            [_activeStyles containsObject:@([UnderlineStyle getStyleType])],
-        .isStrikeThrough =
-            [_activeStyles containsObject:@([StrikethroughStyle getStyleType])],
-        .isColored =
-            [_activeStyles containsObject:@([ColorStyle getStyleType])],
-        .isInlineCode =
-            [_activeStyles containsObject:@([InlineCodeStyle getStyleType])],
-        .isLink = [_activeStyles containsObject:@([LinkStyle getStyleType])],
-        .isMention =
-            [_activeStyles containsObject:@([MentionStyle getStyleType])],
-        .isH1 = [_activeStyles containsObject:@([H1Style getStyleType])],
-        .isH2 = [_activeStyles containsObject:@([H2Style getStyleType])],
-        .isH3 = [_activeStyles containsObject:@([H3Style getStyleType])],
-        .isH4 = [_activeStyles containsObject:@([H4Style getStyleType])],
-        .isH5 = [_activeStyles containsObject:@([H5Style getStyleType])],
-        .isH6 = [_activeStyles containsObject:@([H6Style getStyleType])],
-        .isUnorderedList =
-            [_activeStyles containsObject:@([UnorderedListStyle getStyleType])],
-        .isOrderedList =
-            [_activeStyles containsObject:@([OrderedListStyle getStyleType])],
-        .isBlockQuote =
-            [_activeStyles containsObject:@([BlockQuoteStyle getStyleType])],
-        .isCodeBlock =
-            [_activeStyles containsObject:@([CodeBlockStyle getStyleType])],
-        .isImage = [_activeStyles containsObject:@([ImageStyle getStyleType])],
+          .isBold = [self isStyleActive:[BoldStyle getStyleType]],
+          .isItalic = [self isStyleActive:[ItalicStyle getStyleType]],
+          .isColored = [self isStyleActive:[ColorStyle getStyleType]],
+          .isUnderline = [self isStyleActive:[UnderlineStyle getStyleType]],
+          .isStrikeThrough =
+              [self isStyleActive:[StrikethroughStyle getStyleType]],
+          .isInlineCode = [self isStyleActive:[InlineCodeStyle getStyleType]],
+          .isLink = [self isStyleActive:[LinkStyle getStyleType]],
+          .isMention = [self isStyleActive:[MentionStyle getStyleType]],
+          .isH1 = [self isStyleActive:[H1Style getStyleType]],
+          .isH2 = [self isStyleActive:[H2Style getStyleType]],
+          .isH3 = [self isStyleActive:[H3Style getStyleType]],
+          .isH4 = [self isStyleActive:[H4Style getStyleType]],
+          .isH5 = [self isStyleActive:[H5Style getStyleType]],
+          .isH6 = [self isStyleActive:[H6Style getStyleType]],
+          .isUnorderedList =
+              [self isStyleActive:[UnorderedListStyle getStyleType]],
+          .isOrderedList = [self isStyleActive:[OrderedListStyle getStyleType]],
+          .isBlockQuote = [self isStyleActive:[BlockQuoteStyle getStyleType]],
+          .isCodeBlock = [self isStyleActive:[CodeBlockStyle getStyleType]],
+          .isImage = [self isStyleActive:[ImageStyle getStyleType]],
       });
       emitter->onChangeState(
           {.bold = GET_STYLE_STATE([BoldStyle getStyleType]),

--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -1160,11 +1160,11 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
     [self toggleRegularStyle: [StrikethroughStyle getStyleType]];
   } else if([commandName isEqualToString:@"setColor"]) {
     NSString *colorText = (NSString *)args[0];
-    UIColor *color = [UIColor colorFromString: colorText];
-    [self setColor: color];
+    [self setColor: colorText];
   } else if ([commandName isEqualToString:@"removeColor"]) {
     ColorStyle *colorStyle = stylesDict[@([ColorStyle getStyleType])];
     [colorStyle removeAttributes: textView.selectedRange];
+    [self anyTextMayHaveBeenModified];
   } else if([commandName isEqualToString:@"toggleInlineCode"]) {
     [self toggleRegularStyle: [InlineCodeStyle getStyleType]];
   } else if([commandName isEqualToString:@"addLink"]) {
@@ -1404,10 +1404,17 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
 
 // MARK: - Styles manipulation
 
-- (void)setColor:(UIColor *)color {
+- (void)setColor:(NSString *)colorText {
   ColorStyle *colorStyle = stylesDict[@(Colored)];
+  UIColor *color = [UIColor colorFromString: colorText];
   
   [colorStyle applyStyle:textView.selectedRange color: color];
+  [self anyTextMayHaveBeenModified];
+}
+
+- (void)removeColor {
+  ColorStyle *colorStyle = stylesDict[@(Colored)];
+  [colorStyle removeAttributes: textView.selectedRange];
   [self anyTextMayHaveBeenModified];
 }
 

--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -1162,9 +1162,7 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
     NSString *colorText = (NSString *)args[0];
     [self setColor: colorText];
   } else if ([commandName isEqualToString:@"removeColor"]) {
-    ColorStyle *colorStyle = stylesDict[@([ColorStyle getStyleType])];
-    [colorStyle removeAttributes: textView.selectedRange];
-    [self anyTextMayHaveBeenModified];
+    [self removeColor];
   } else if([commandName isEqualToString:@"toggleInlineCode"]) {
     [self toggleRegularStyle: [InlineCodeStyle getStyleType]];
   } else if([commandName isEqualToString:@"addLink"]) {

--- a/ios/inputParser/InputParser.mm
+++ b/ios/inputParser/InputParser.mm
@@ -264,12 +264,15 @@
       NSMutableSet *fixedEndedStyles = [endedStyles mutableCopy];
       NSMutableSet *stylesToBeReAdded = [[NSMutableSet alloc] init];
       
-      for (NSNumber *style in endedStyles) {
+      for(NSNumber *style in endedStyles) {
         NSInteger styleBeginning = [currentActiveStylesBeginning[style] integerValue];
         
         for(NSNumber *activeStyle in currentActiveStyles) {
           NSInteger activeStyleBeginning = [currentActiveStylesBeginning[activeStyle] integerValue];
-          
+
+          // we end the styles that began after the currently ended style but not at the "i" (cause the old style ended at exactly "i-1"
+          // also the ones that began in the exact same place but are "inner" in relation to them due to StyleTypeEnum integer values
+
           if((activeStyleBeginning > styleBeginning && activeStyleBeginning < i) ||
              (activeStyleBeginning == styleBeginning && activeStyleBeginning < i && [activeStyle integerValue]  > [style integerValue])) {
             [fixedEndedStyles addObject:activeStyle];

--- a/ios/inputParser/InputParser.mm
+++ b/ios/inputParser/InputParser.mm
@@ -4,6 +4,7 @@
 #import "StyleHeaders.h"
 #import "TextInsertionUtils.h"
 #import "UIView+React.h"
+#import "ColorExtension.h"
 
 @implementation InputParser {
   EnrichedTextInputView *_input;
@@ -34,8 +35,11 @@
   BOOL inBlockQuote = NO;
   BOOL inCodeBlock = NO;
   unichar lastCharacter = 0;
+  
+  // Track current values for valued styles
+  UIColor *previousColor = nil;
 
-  for (int i = 0; i < text.length; i++) {
+  for(int i = 0; i < text.length; i++) {
     NSRange currentRange = NSMakeRange(offset + i, 1);
     NSMutableSet<NSNumber *> *currentActiveStyles =
         [[NSMutableSet<NSNumber *> alloc] init];
@@ -55,19 +59,28 @@
         [currentActiveStylesBeginning removeObjectForKey:type];
       }
     }
-
-    NSString *currentCharacterStr =
-        [_input->textView.textStorage.string substringWithRange:currentRange];
-    unichar currentCharacterChar = [_input->textView.textStorage.string
-        characterAtIndex:currentRange.location];
-
-    if ([[NSCharacterSet newlineCharacterSet]
-            characterIsMember:currentCharacterChar]) {
-      if (newLine) {
-        // we can either have an empty list item OR need to close the list and
-        // put a BR in such a situation the existence of the list must be
-        // checked on 0 length range, not on the newline character
-        if (inOrderedList) {
+    
+    // Handle valued styles changes
+    UIColor *currentColor = nil;
+    
+    if([currentActiveStyles containsObject:@(Colored)]) {
+      ColorStyle *colorStyle = _input->stylesDict[@(Colored)];
+      currentColor = [colorStyle getColorAt:currentRange.location];
+      if(previousColor && ![currentColor isEqual:previousColor]) {
+        // Treat as end of previous color and start of new
+        [currentActiveStyles removeObject:@(Colored)];
+        currentActiveStylesBeginning[@(Colored)] = [NSNumber numberWithInt:i];
+      }
+    }
+    
+    NSString *currentCharacterStr = [_input->textView.textStorage.string substringWithRange:currentRange];
+    unichar currentCharacterChar = [_input->textView.textStorage.string characterAtIndex:currentRange.location];
+    
+    if([[NSCharacterSet newlineCharacterSet] characterIsMember:currentCharacterChar]) {
+      if(newLine) {
+        // we can either have an empty list item OR need to close the list and put a BR in such a situation
+        // the existence of the list must be checked on 0 length range, not on the newline character
+        if(inOrderedList) {
           OrderedListStyle *oStyle = _input->stylesDict[@(OrderedList)];
           BOOL detected =
               [oStyle detectStyle:NSMakeRange(currentRange.location, 0)];
@@ -152,10 +165,11 @@
           [result appendString:@"</p>"];
         }
       }
-
-      // clear the previous styles
-      previousActiveStyles = [[NSSet<NSNumber *> alloc] init];
-
+      
+      // clear the previous styles and valued trackers
+      previousActiveStyles = [[NSSet<NSNumber *> alloc]init];
+      previousColor = nil;
+      
       // next character opens new paragraph
       newLine = YES;
     } else {
@@ -243,33 +257,21 @@
       }
 
       // get styles that have ended
-      NSMutableSet<NSNumber *> *endedStyles =
-          [previousActiveStyles mutableCopy];
-      [endedStyles minusSet:currentActiveStyles];
-
-      // also finish styles that should be ended becasue they are nested in a
-      // style that ended
+      NSMutableSet<NSNumber *> *endedStyles = [previousActiveStyles mutableCopy];
+      [endedStyles minusSet: currentActiveStyles];
+      
+      // also finish styles that should be ended because they are nested in a style that ended
       NSMutableSet *fixedEndedStyles = [endedStyles mutableCopy];
       NSMutableSet *stylesToBeReAdded = [[NSMutableSet alloc] init];
-
+      
       for (NSNumber *style in endedStyles) {
-        NSInteger styleBeginning =
-            [currentActiveStylesBeginning[style] integerValue];
-
-        for (NSNumber *activeStyle in currentActiveStyles) {
-          NSInteger activeStyleBeginning =
-              [currentActiveStylesBeginning[activeStyle] integerValue];
-
-          // we end the styles that began after the currently ended style but
-          // not at the "i" (cause the old style ended at exactly "i-1" also the
-          // ones that began in the exact same place but are "inner" in relation
-          // to them due to StyleTypeEnum integer values
-
-          if ((activeStyleBeginning > styleBeginning &&
-               activeStyleBeginning < i) ||
-              (activeStyleBeginning == styleBeginning &&
-               activeStyleBeginning<
-                   i && [activeStyle integerValue]>[style integerValue])) {
+        NSInteger styleBeginning = [currentActiveStylesBeginning[style] integerValue];
+        
+        for(NSNumber *activeStyle in currentActiveStyles) {
+          NSInteger activeStyleBeginning = [currentActiveStylesBeginning[activeStyle] integerValue];
+          
+          if((activeStyleBeginning > styleBeginning && activeStyleBeginning < i) ||
+             (activeStyleBeginning == styleBeginning && activeStyleBeginning < i && [activeStyle integerValue]  > [style integerValue])) {
             [fixedEndedStyles addObject:activeStyle];
             [stylesToBeReAdded addObject:activeStyle];
           }
@@ -341,6 +343,8 @@
 
       // save current styles for next character's checks
       previousActiveStyles = currentActiveStyles;
+      
+      previousColor = currentColor;
     }
 
     // set last character
@@ -467,7 +471,18 @@
     return @"u";
   } else if ([style isEqualToNumber:@([StrikethroughStyle getStyleType])]) {
     return @"s";
-  } else if ([style isEqualToNumber:@([InlineCodeStyle getStyleType])]) {
+  } else if([style isEqualToNumber:@([ColorStyle getStyleType])]) {
+    if(openingTag) {
+      ColorStyle *colorSpan = _input->stylesDict[@([ColorStyle getStyleType])];
+      UIColor *color = [colorSpan getColorAt: location];
+      if(color) {
+        NSString *hex = [color hexString];
+        return [NSString stringWithFormat:@"font color=\"%@\"", hex];
+      };
+    } else {
+      return @"font";
+    }
+  } else if([style isEqualToNumber: @([InlineCodeStyle getStyleType])]) {
     return @"code";
   } else if ([style isEqualToNumber:@([LinkStyle getStyleType])]) {
     if (openingTag) {
@@ -631,9 +646,10 @@
                                                 params:params];
       } else if ([styleType isEqualToNumber:@([ImageStyle getStyleType])]) {
         ImageData *imgData = (ImageData *)stylePair.styleValue;
-        [((ImageStyle *)baseStyle) addImageAtRange:styleRange
-                                         imageData:imgData
-                                     withSelection:NO];
+        [((ImageStyle *)baseStyle) addImageAtRange:styleRange imageData:imgData withSelection:NO];
+      } else if([styleType isEqualToNumber: @([ColorStyle getStyleType])]) {
+        UIColor *color = (UIColor *)stylePair.styleValue;
+        [((ColorStyle *)baseStyle) applyStyle:styleRange color: color];
       } else {
         BOOL shouldAddTypingAttr =
             styleRange.location + styleRange.length == plainTextLength;
@@ -1187,7 +1203,24 @@
       [styleArr addObject:@([UnderlineStyle getStyleType])];
     } else if ([tagName isEqualToString:@"s"]) {
       [styleArr addObject:@([StrikethroughStyle getStyleType])];
-    } else if ([tagName isEqualToString:@"code"]) {
+    } else if([tagName isEqualToString:@"font"]) {
+      [styleArr addObject:@([ColorStyle getStyleType])];
+
+      NSString *pattern = @"color=\"([^\"]+)\"";
+      NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:nil];
+      NSTextCheckingResult *match = [regex firstMatchInString:params options:0 range:NSMakeRange(0, params.length)];
+
+      if(match.numberOfRanges == 2) {
+          NSString *colorString = [params substringWithRange:[match rangeAtIndex:1]];
+          
+          UIColor *color = [UIColor colorFromString:colorString];
+          if(color == nil) {
+            continue;
+          }
+          
+          stylePair.styleValue = color;
+      }
+    } else if([tagName isEqualToString:@"code"]) {
       [styleArr addObject:@([InlineCodeStyle getStyleType])];
     } else if ([tagName isEqualToString:@"a"]) {
       NSRegularExpression *hrefRegex =

--- a/ios/inputParser/InputParser.mm
+++ b/ios/inputParser/InputParser.mm
@@ -60,19 +60,30 @@
       }
     }
     
-    // Handle valued styles changes
     UIColor *currentColor = nil;
-    
+        
     if([currentActiveStyles containsObject:@(Colored)]) {
       ColorStyle *colorStyle = _input->stylesDict[@(Colored)];
       currentColor = [colorStyle getColorAt:currentRange.location];
-      if(previousColor && ![currentColor isEqual:previousColor]) {
-        // Treat as end of previous color and start of new
-        [currentActiveStyles removeObject:@(Colored)];
-        currentActiveStylesBeginning[@(Colored)] = [NSNumber numberWithInt:i];
+       // If the end of one color overlaps exactly with the start of the next
+       // the previous font tag should be closed and a new one opened using the new color.
+      if (previousColor && ![currentColor isEqual:previousColor]) {
+          NSString *closeTag = [self tagContentForStyle:@(Colored)
+                                             openingTag:NO
+                                               location:currentRange.location];
+          [result appendFormat:@"</%@>", closeTag];
+          NSString *openTag = [self tagContentForStyle:@(Colored)
+                                            openingTag:YES
+                                              location:currentRange.location];
+          [result appendFormat:@"<%@>", openTag];
+          NSString *currentCharacterStr = [_input->textView.textStorage.string substringWithRange:currentRange];
+          [result appendString: currentCharacterStr];
+          previousColor = currentColor;
+          [currentActiveStyles addObject:@(Colored)];
+          continue;
       }
     }
-    
+
     NSString *currentCharacterStr = [_input->textView.textStorage.string substringWithRange:currentRange];
     unichar currentCharacterChar = [_input->textView.textStorage.string characterAtIndex:currentRange.location];
     

--- a/ios/styles/BlockQuoteStyle.mm
+++ b/ios/styles/BlockQuoteStyle.mm
@@ -18,6 +18,10 @@
   return YES;
 }
 
++ (NSAttributedStringKey)attributeKey {
+  return NSParagraphStyleAttributeName;
+}
+
 - (instancetype)initWithInput:(id)input {
   self = [super init];
   _input = (EnrichedTextInputView *)input;
@@ -186,7 +190,7 @@
   return NO;
 }
 
-- (BOOL)styleCondition:(id _Nullable)value:(NSRange)range {
+- (BOOL)styleCondition:(id _Nullable)value range:(NSRange)range {
   NSParagraphStyle *pStyle = (NSParagraphStyle *)value;
   return pStyle != nullptr && pStyle.headIndent == [self getHeadIndent] &&
          pStyle.firstLineHeadIndent == [self getHeadIndent] &&
@@ -199,7 +203,7 @@
                         withInput:_input
                           inRange:range
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   } else {
     return [OccurenceUtils detect:NSParagraphStyleAttributeName
@@ -207,7 +211,7 @@
                           atIndex:range.location
                     checkPrevious:YES
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   }
 }
@@ -217,7 +221,7 @@
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 
@@ -226,7 +230,7 @@
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 

--- a/ios/styles/BoldStyle.mm
+++ b/ios/styles/BoldStyle.mm
@@ -15,6 +15,10 @@
   return NO;
 }
 
++ (NSAttributedStringKey)attributeKey {
+  return NSFontAttributeName;
+}
+
 - (instancetype)initWithInput:(id)input {
   self = [super init];
   _input = (EnrichedTextInputView *)input;
@@ -123,7 +127,7 @@
                           : [headingStyle detectStyle:range];
 }
 
-- (BOOL)styleCondition:(id _Nullable)value:(NSRange)range {
+- (BOOL)styleCondition:(id _Nullable)value range:(NSRange)range {
   UIFont *font = (UIFont *)value;
   return font != nullptr && [font isBold] &&
          ![self boldHeadingConflictsInRange:range type:H1] &&
@@ -140,7 +144,7 @@
                         withInput:_input
                           inRange:range
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   } else {
     return [OccurenceUtils detect:NSFontAttributeName
@@ -148,7 +152,7 @@
                           atIndex:range.location
                     checkPrevious:NO
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   }
 }
@@ -158,7 +162,7 @@
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 
@@ -167,7 +171,7 @@
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 

--- a/ios/styles/CodeBlockStyle.mm
+++ b/ios/styles/CodeBlockStyle.mm
@@ -15,6 +15,10 @@
   return CodeBlock;
 }
 
++ (NSAttributedStringKey)attributeKey {
+  return NSParagraphStyleAttributeName;
+}
+
 + (BOOL)isParagraphStyle {
   return YES;
 }
@@ -177,7 +181,7 @@
   return NO;
 }
 
-- (BOOL)styleCondition:(id _Nullable)value:(NSRange)range {
+- (BOOL)styleCondition:(id _Nullable)value range:(NSRange)range {
   NSParagraphStyle *paragraph = (NSParagraphStyle *)value;
   return paragraph != nullptr && paragraph.textLists.count == 1 &&
          [paragraph.textLists.firstObject.markerFormat
@@ -190,7 +194,7 @@
                         withInput:_input
                           inRange:range
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   } else {
     return [OccurenceUtils detect:NSParagraphStyleAttributeName
@@ -198,7 +202,7 @@
                           atIndex:range.location
                     checkPrevious:YES
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   }
 }
@@ -208,7 +212,7 @@
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 
@@ -217,7 +221,7 @@
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 

--- a/ios/styles/ColorStyle.mm
+++ b/ios/styles/ColorStyle.mm
@@ -303,4 +303,14 @@
     return baseColor;
 }
 
+- (void)removeColorInSelectedRange {
+  NSRange selectedRange = _input->textView.selectedRange;
+  
+  if(selectedRange.length > 0) {
+    [self removeAttributes: selectedRange];
+  } else {
+    [self removeTypingAttributes];
+  }
+}
+
 @end

--- a/ios/styles/ColorStyle.mm
+++ b/ios/styles/ColorStyle.mm
@@ -20,6 +20,8 @@
 - (void)applyStyle:(NSRange)range {
 }
 
++ (BOOL)isParagraphStyle { return NO; }
+
 - (void)applyStyle:(NSRange)range color:(UIColor *)color {
   BOOL isStylePresent = [self detectStyle:range color:color];
   
@@ -136,6 +138,12 @@
           : [style detectStyle:range]);
 }
 
+- (BOOL)isInCodeBlockAndHasTheSameColor:(id)value :(NSRange)range {
+  BOOL isInCodeBlock = [self isInStyle:range styleType: CodeBlock];
+  
+  return isInCodeBlock && [(UIColor *)value isEqualToColor:[_input->config codeBlockFgColor]];
+}
+
 - (BOOL)inLinkAndForegroundColorIsLinkColor:(id)value :(NSRange)range {
   BOOL isInLink = [self isInStyle:range styleType: Link];
   
@@ -176,6 +184,7 @@
   if ([self inLinkAndForegroundColorIsLinkColor:value :range]) { return NO; }
   if ([self inInlineCodeAndHasTheSameColor:value :range]) { return NO; }
   if ([self inMentionAndHasTheSameColor:value :range]) { return NO; }
+  if ([self isInCodeBlockAndHasTheSameColor:value :range]) { return NO; }
   
   return YES;
 }

--- a/ios/styles/ColorStyle.mm
+++ b/ios/styles/ColorStyle.mm
@@ -1,0 +1,297 @@
+#import "StyleHeaders.h"
+#import "EnrichedTextInputView.h"
+#import "OccurenceUtils.h"
+#import "FontExtension.h"
+#import "StyleTypeEnum.h"
+#import "ColorExtension.h"
+
+@implementation ColorStyle {
+    EnrichedTextInputView *_input;
+}
+
++ (StyleType)getStyleType { return Colored; }
+
+- (instancetype)initWithInput:(id)input {
+  self = [super init];
+  _input = (EnrichedTextInputView *)input;
+  return self;
+}
+
+- (void)applyStyle:(NSRange)range {
+}
+
+- (void)applyStyle:(NSRange)range color:(UIColor *)color {
+  BOOL isStylePresent = [self detectStyle:range color:color];
+  
+  if (range.length >= 1) {
+      isStylePresent ? [self removeAttributes:range] : [self addAttributes:range color: color];
+  } else {
+      isStylePresent ? [self removeTypingAttributes] : [self addTypingAttributes: color];
+  }
+}
+
+#pragma mark - Add attributes
+
+- (void)addAttributes:(NSRange)range {
+}
+
+- (void)addAttributes:(NSRange)range color:(UIColor *)color {
+  if (color == nil) return;
+  [_input->textView.textStorage beginEditing];
+  [_input->textView.textStorage addAttributes:@{
+      NSForegroundColorAttributeName: color,
+      NSUnderlineColorAttributeName: color,
+      NSStrikethroughColorAttributeName: color
+  } range:range];
+  [_input->textView.textStorage endEditing];
+  _color = color;
+}
+
+- (void)addTypingAttributes {
+}
+
+-(void)addTypingAttributes:(UIColor *)color {
+  NSMutableDictionary *newTypingAttrs = [_input->textView.typingAttributes mutableCopy];
+  newTypingAttrs[NSForegroundColorAttributeName] = color;
+  newTypingAttrs[NSUnderlineColorAttributeName] = color;
+  newTypingAttrs[NSStrikethroughColorAttributeName] = color;
+  _input->textView.typingAttributes = newTypingAttrs;
+}
+
+#pragma mark - Remove attributes
+
+- (void)removeAttributes:(NSRange)range {
+    NSTextStorage *textStorage = _input->textView.textStorage;
+    
+    LinkStyle *linkStyle = _input->stylesDict[@(Link)];
+    InlineCodeStyle *inlineCodeStyle = _input->stylesDict[@(InlineCode)];
+    BlockQuoteStyle *blockQuoteStyle = _input->stylesDict[@(BlockQuote)];
+    MentionStyle *mentionStyle = _input->stylesDict[@(Mention)];
+    
+    NSArray<StylePair *> *linkOccurrences = [linkStyle findAllOccurences:range];
+    NSArray<StylePair *> *inlineOccurrences = [inlineCodeStyle findAllOccurences:range];
+    NSArray<StylePair *> *blockQuoteOccurrences = [blockQuoteStyle findAllOccurences:range];
+    NSArray<StylePair *> *mentionOccurrences = [mentionStyle findAllOccurences:range];
+    
+    NSMutableSet<NSNumber *> *points = [NSMutableSet new];
+    [points addObject:@(range.location)];
+    [points addObject:@(NSMaxRange(range))];
+    
+    for (StylePair *pair in linkOccurrences) {
+        [points addObject:@([pair.rangeValue rangeValue].location)];
+        [points addObject:@(NSMaxRange([pair.rangeValue rangeValue]))];
+    }
+    for (StylePair *pair in inlineOccurrences) {
+        [points addObject:@([pair.rangeValue rangeValue].location)];
+        [points addObject:@(NSMaxRange([pair.rangeValue rangeValue]))];
+    }
+    for (StylePair *pair in blockQuoteOccurrences) {
+        [points addObject:@([pair.rangeValue rangeValue].location)];
+        [points addObject:@(NSMaxRange([pair.rangeValue rangeValue]))];
+    }
+    for (StylePair *pair in mentionOccurrences) {
+        [points addObject:@([pair.rangeValue rangeValue].location)];
+        [points addObject:@(NSMaxRange([pair.rangeValue rangeValue]))];
+    }
+    
+    NSArray<NSNumber *> *sortedPoints = [points.allObjects sortedArrayUsingSelector:@selector(compare:)];
+    
+    [textStorage beginEditing];
+    for (NSUInteger i = 0; i < sortedPoints.count - 1; i++) {
+        NSUInteger start = sortedPoints[i].unsignedIntegerValue;
+        NSUInteger end = sortedPoints[i + 1].unsignedIntegerValue;
+        if (start >= end) continue;
+        
+        NSRange subrange = NSMakeRange(start, end - start);
+        
+        UIColor *baseColor = [self baseColorForLocation: subrange.location];
+        
+        [textStorage addAttribute:NSForegroundColorAttributeName value:baseColor range:subrange];
+        [textStorage addAttribute:NSUnderlineColorAttributeName value:baseColor range:subrange];
+        [textStorage addAttribute:NSStrikethroughColorAttributeName value:baseColor range:subrange];
+    }
+    [textStorage endEditing];
+}
+
+- (void)removeTypingAttributes {
+      NSMutableDictionary *newTypingAttrs = [_input->textView.typingAttributes mutableCopy];
+      NSRange selectedRange = _input->textView.selectedRange;
+      NSUInteger location = selectedRange.location;
+      
+      UIColor *baseColor = [self baseColorForLocation:location];
+      
+      newTypingAttrs[NSForegroundColorAttributeName] = baseColor;
+      newTypingAttrs[NSUnderlineColorAttributeName] = baseColor;
+      newTypingAttrs[NSStrikethroughColorAttributeName] = baseColor;
+      _input->textView.typingAttributes = newTypingAttrs;
+}
+
+#pragma mark - Detection
+
+-(BOOL)isInStyle:(NSRange) range styleType:(StyleType)styleType {
+  id<BaseStyleProtocol> style = _input->stylesDict[@(styleType)];
+  
+  return (range.length > 0
+          ? [style anyOccurence:range]
+          : [style detectStyle:range]);
+}
+
+- (BOOL)inLinkAndForegroundColorIsLinkColor:(id)value :(NSRange)range {
+  BOOL isInLink = [self isInStyle:range styleType: Link];
+  
+  return isInLink && [(UIColor *)value isEqualToColor:[_input->config linkColor]];
+}
+
+- (BOOL)inInlineCodeAndHasTheSameColor:(id)value :(NSRange)range {
+  BOOL isInInlineCode = [self isInStyle:range styleType:InlineCode];
+  
+  return isInInlineCode && [(UIColor *)value isEqualToColor:[_input->config inlineCodeFgColor]];
+}
+
+- (BOOL)inBlockQuoteAndHasTheSameColor:(id)value :(NSRange)range {
+  BOOL isInBlockQuote = [self isInStyle:range styleType:BlockQuote];
+  
+  return isInBlockQuote && [(UIColor *)value isEqualToColor:[_input->config blockquoteColor]];
+}
+
+- (BOOL)inMentionAndHasTheSameColor:(id)value :(NSRange)range {
+  MentionStyle *mentionStyle = _input->stylesDict[@(Mention)];
+  BOOL isInMention = [self isInStyle:range styleType:Mention];
+  
+  if (!isInMention) return NO;
+  
+  MentionParams *params = [mentionStyle getMentionParamsAt:range.location];
+  if (params == nil) return NO;
+  
+  MentionStyleProps *styleProps = [_input->config mentionStylePropsForIndicator:params.indicator];
+  
+  return [(UIColor *)value isEqualToColor:styleProps.color];
+}
+
+- (BOOL)styleCondition:(id)value :(NSRange)range {
+  if (value == nil) { return NO; }
+  
+  if ([(UIColor *)value isEqualToColor:_input->config.primaryColor]) { return NO; }
+  if ([self inBlockQuoteAndHasTheSameColor:value :range]) { return NO; }
+  if ([self inLinkAndForegroundColorIsLinkColor:value :range]) { return NO; }
+  if ([self inInlineCodeAndHasTheSameColor:value :range]) { return NO; }
+  if ([self inMentionAndHasTheSameColor:value :range]) { return NO; }
+  
+  return YES;
+}
+
+- (BOOL)detectStyle:(NSRange)range {
+  UIColor *color = [self getColorInRange:range];
+  
+  return [self detectStyle:range color:color];
+}
+
+- (BOOL)detectStyle:(NSRange)range color:(UIColor *)color {
+  if(range.length >= 1) {
+    return [OccurenceUtils detect:NSForegroundColorAttributeName withInput:_input inRange:range
+      withCondition: ^BOOL(id _Nullable value, NSRange range) {
+        return [(UIColor *)value isEqualToColor:color] && [self styleCondition:value :range];
+      }
+    ];
+  } else {
+    return [OccurenceUtils detect:NSForegroundColorAttributeName withInput:_input atIndex:range.location checkPrevious:YES
+      withCondition:^BOOL(id _Nullable value, NSRange range) {
+        return [(UIColor *)value isEqualToColor:color] && [self styleCondition:value :range];
+      }
+    ];
+  }
+}
+
+- (BOOL)detectExcludingColor:(UIColor *)excludedColor inRange:(NSRange)range {
+    if (![self detectStyle:range]) {
+        return NO;
+    }
+    UIColor *currentColor = [self getColorInRange:range];
+    return currentColor != nil && ![currentColor isEqualToColor:excludedColor];
+}
+
+- (BOOL)anyOccurence:(NSRange)range {
+  return [OccurenceUtils any:NSForegroundColorAttributeName withInput:_input inRange:range
+    withCondition:^BOOL(id _Nullable value, NSRange range) {
+      return [self styleCondition:value :range];
+    }
+  ];
+}
+
+- (NSArray<StylePair *> *_Nullable)findAllOccurences:(NSRange)range {
+  return [OccurenceUtils all:NSForegroundColorAttributeName withInput:_input inRange:range
+    withCondition:^BOOL(id _Nullable value, NSRange range) {
+      return [self styleCondition:value :range];
+    }
+  ];
+}
+
+- (UIColor *)getColorAt:(NSUInteger)location {
+  NSRange effectiveRange = NSMakeRange(0, 0);
+  NSRange inputRange = NSMakeRange(0, _input->textView.textStorage.length);
+  
+  if(location == _input->textView.textStorage.length) {
+    UIColor *typingColor = _input->textView.typingAttributes[NSForegroundColorAttributeName];
+    return typingColor ?: [_input->config primaryColor];
+  }
+  
+  return [_input->textView.textStorage
+    attribute:NSForegroundColorAttributeName
+    atIndex:location
+    longestEffectiveRange: &effectiveRange
+    inRange:inputRange
+  ];
+}
+
+- (UIColor *)getColorInRange:(NSRange)range {
+  NSUInteger location = range.location;
+  NSUInteger length = range.length;
+  
+  NSRange effectiveRange = NSMakeRange(0, 0);
+  NSRange inputRange = NSMakeRange(0, _input->textView.textStorage.length);
+  
+  if(location == _input->textView.textStorage.length) {
+    UIColor *typingColor = _input->textView.typingAttributes[NSForegroundColorAttributeName];
+    return typingColor ?: [_input->config primaryColor];
+  }
+  
+  NSUInteger queryLocation = location;
+  if (length == 0 && location > 0) {
+      queryLocation = location - 1;
+  }
+  
+  UIColor *color = [_input->textView.textStorage
+    attribute:NSForegroundColorAttributeName
+    atIndex:queryLocation
+    longestEffectiveRange: &effectiveRange
+    inRange:inputRange
+  ];
+  
+  return color;
+}
+
+- (UIColor *)baseColorForLocation:(NSUInteger)location {
+    BOOL inLink = [self isInStyle:NSMakeRange(location, 0) styleType:Link];
+    BOOL inInlineCode = [self isInStyle:NSMakeRange(location, 0) styleType:InlineCode];
+    BOOL inBlockQuote = [self isInStyle:NSMakeRange(location, 0) styleType:BlockQuote];
+    BOOL inMention = [self isInStyle:NSMakeRange(location, 0) styleType:Mention];
+    
+    UIColor *baseColor = [_input->config primaryColor];
+    if (inMention) {
+        MentionStyle *mentionStyle = _input->stylesDict[@(Mention)];
+        MentionParams *params = [mentionStyle getMentionParamsAt:location];
+        if (params != nil) {
+            MentionStyleProps *styleProps = [_input->config mentionStylePropsForIndicator:params.indicator];
+            baseColor = styleProps.color;
+        }
+    } else if (inLink) {
+        baseColor = [_input->config linkColor];
+    } else if (inInlineCode) {
+        baseColor = [_input->config inlineCodeFgColor];
+    } else if (inBlockQuote) {
+        baseColor = [_input->config blockquoteColor];
+    }
+    return baseColor;
+}
+
+@end

--- a/ios/styles/ColorStyle.mm
+++ b/ios/styles/ColorStyle.mm
@@ -1,15 +1,40 @@
-#import "StyleHeaders.h"
-#import "EnrichedTextInputView.h"
-#import "OccurenceUtils.h"
-#import "FontExtension.h"
-#import "StyleTypeEnum.h"
 #import "ColorExtension.h"
+#import "EnrichedTextInputView.h"
+#import "FontExtension.h"
+#import "OccurenceUtils.h"
+#import "StyleHeaders.h"
+#import "StyleTypeEnum.h"
 
 @implementation ColorStyle {
-    EnrichedTextInputView *_input;
+  EnrichedTextInputView *_input;
 }
 
-+ (StyleType)getStyleType { return Colored; }
+- (NSArray<NSNumber *> *)coloredStyleTypes {
+  static NSArray<NSNumber *> *types = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    types = @[
+      @(Link),
+      @(InlineCode),
+      @(BlockQuote),
+      @(CodeBlock),
+      @(Mention),
+    ];
+  });
+  return types;
+}
+
++ (StyleType)getStyleType {
+  return Colored;
+}
+
++ (NSAttributedStringKey)attributeKey {
+  return NSForegroundColorAttributeName;
+}
+
++ (BOOL)isParagraphStyle {
+  return NO;
+}
 
 - (instancetype)initWithInput:(id)input {
   self = [super init];
@@ -20,31 +45,38 @@
 - (void)applyStyle:(NSRange)range {
 }
 
-+ (BOOL)isParagraphStyle { return NO; }
++ (NSDictionary *)getParametersFromValue:(id)value {
+  UIColor *color = value;
+
+  return @{
+    @"color" : [color hexString],
+  };
+}
 
 - (void)applyStyle:(NSRange)range color:(UIColor *)color {
   BOOL isStylePresent = [self detectStyle:range color:color];
-  
+
   if (range.length >= 1) {
-      isStylePresent ? [self removeAttributes:range] : [self addAttributes:range color: color];
+    isStylePresent ? [self removeAttributes:range]
+                   : [self addAttributes:range color:color];
   } else {
-      isStylePresent ? [self removeTypingAttributes] : [self addTypingAttributes: color];
+    isStylePresent ? [self removeTypingAttributes]
+                   : [self addTypingAttributes:color];
   }
 }
 
 #pragma mark - Add attributes
 
-- (void)addAttributes:(NSRange)range {
-}
-
 - (void)addAttributes:(NSRange)range color:(UIColor *)color {
-  if (color == nil) return;
+  if (color == nil)
+    return;
   [_input->textView.textStorage beginEditing];
   [_input->textView.textStorage addAttributes:@{
-      NSForegroundColorAttributeName: color,
-      NSUnderlineColorAttributeName: color,
-      NSStrikethroughColorAttributeName: color
-  } range:range];
+    NSForegroundColorAttributeName : color,
+    NSUnderlineColorAttributeName : color,
+    NSStrikethroughColorAttributeName : color
+  }
+                                        range:range];
   [_input->textView.textStorage endEditing];
   _color = color;
 }
@@ -52,8 +84,9 @@
 - (void)addTypingAttributes {
 }
 
--(void)addTypingAttributes:(UIColor *)color {
-  NSMutableDictionary *newTypingAttrs = [_input->textView.typingAttributes mutableCopy];
+- (void)addTypingAttributes:(UIColor *)color {
+  NSMutableDictionary *newTypingAttrs =
+      [_input->textView.typingAttributes mutableCopy];
   newTypingAttrs[NSForegroundColorAttributeName] = color;
   newTypingAttrs[NSUnderlineColorAttributeName] = color;
   newTypingAttrs[NSStrikethroughColorAttributeName] = color;
@@ -63,253 +96,276 @@
 #pragma mark - Remove attributes
 
 - (void)removeAttributes:(NSRange)range {
-    NSTextStorage *textStorage = _input->textView.textStorage;
-    
-    LinkStyle *linkStyle = _input->stylesDict[@(Link)];
-    InlineCodeStyle *inlineCodeStyle = _input->stylesDict[@(InlineCode)];
-    BlockQuoteStyle *blockQuoteStyle = _input->stylesDict[@(BlockQuote)];
-    MentionStyle *mentionStyle = _input->stylesDict[@(Mention)];
-    
-    NSArray<StylePair *> *linkOccurrences = [linkStyle findAllOccurences:range];
-    NSArray<StylePair *> *inlineOccurrences = [inlineCodeStyle findAllOccurences:range];
-    NSArray<StylePair *> *blockQuoteOccurrences = [blockQuoteStyle findAllOccurences:range];
-    NSArray<StylePair *> *mentionOccurrences = [mentionStyle findAllOccurences:range];
-    
-    NSMutableSet<NSNumber *> *points = [NSMutableSet new];
-    [points addObject:@(range.location)];
-    [points addObject:@(NSMaxRange(range))];
-    
-    for (StylePair *pair in linkOccurrences) {
-        [points addObject:@([pair.rangeValue rangeValue].location)];
-        [points addObject:@(NSMaxRange([pair.rangeValue rangeValue]))];
-    }
-    for (StylePair *pair in inlineOccurrences) {
-        [points addObject:@([pair.rangeValue rangeValue].location)];
-        [points addObject:@(NSMaxRange([pair.rangeValue rangeValue]))];
-    }
-    for (StylePair *pair in blockQuoteOccurrences) {
-        [points addObject:@([pair.rangeValue rangeValue].location)];
-        [points addObject:@(NSMaxRange([pair.rangeValue rangeValue]))];
-    }
-    for (StylePair *pair in mentionOccurrences) {
-        [points addObject:@([pair.rangeValue rangeValue].location)];
-        [points addObject:@(NSMaxRange([pair.rangeValue rangeValue]))];
-    }
-    
-    NSArray<NSNumber *> *sortedPoints = [points.allObjects sortedArrayUsingSelector:@selector(compare:)];
-    
-    [textStorage beginEditing];
-    for (NSUInteger i = 0; i < sortedPoints.count - 1; i++) {
-        NSUInteger start = sortedPoints[i].unsignedIntegerValue;
-        NSUInteger end = sortedPoints[i + 1].unsignedIntegerValue;
-        if (start >= end) continue;
-        
-        NSRange subrange = NSMakeRange(start, end - start);
-        
-        UIColor *baseColor = [self baseColorForLocation: subrange.location];
-        
-        [textStorage addAttribute:NSForegroundColorAttributeName value:baseColor range:subrange];
-        [textStorage addAttribute:NSUnderlineColorAttributeName value:baseColor range:subrange];
-        [textStorage addAttribute:NSStrikethroughColorAttributeName value:baseColor range:subrange];
-    }
-    [textStorage endEditing];
+  NSTextStorage *textStorage = _input->textView.textStorage;
+  if (range.length == 0)
+    return;
+
+  NSUInteger len = textStorage.length;
+  if (range.location >= len)
+    return;
+
+  NSUInteger max = MIN(NSMaxRange(range), len);
+
+  [textStorage beginEditing];
+
+  for (NSUInteger i = range.location; i < max; i++) {
+    UIColor *restoreColor = [self originalColorAtIndex:i];
+    NSDictionary *newAttributes = @{
+      NSForegroundColorAttributeName : restoreColor,
+      NSUnderlineColorAttributeName : restoreColor,
+      NSForegroundColorAttributeName : restoreColor,
+    };
+    [textStorage addAttributes:newAttributes range:NSMakeRange(i, 1)];
+  }
+
+  [textStorage endEditing];
 }
 
 - (void)removeTypingAttributes {
-      NSMutableDictionary *newTypingAttrs = [_input->textView.typingAttributes mutableCopy];
-      NSRange selectedRange = _input->textView.selectedRange;
-      NSUInteger location = selectedRange.location;
-      
-      UIColor *baseColor = [self baseColorForLocation:location];
-      
-      newTypingAttrs[NSForegroundColorAttributeName] = baseColor;
-      newTypingAttrs[NSUnderlineColorAttributeName] = baseColor;
-      newTypingAttrs[NSStrikethroughColorAttributeName] = baseColor;
-      _input->textView.typingAttributes = newTypingAttrs;
+  NSMutableDictionary *newTypingAttrs =
+      [_input->textView.typingAttributes mutableCopy];
+  NSRange selectedRange = _input->textView.selectedRange;
+  NSUInteger location = selectedRange.location;
+
+  UIColor *baseColor = [self originalColorAtIndex:location];
+
+  newTypingAttrs[NSForegroundColorAttributeName] = baseColor;
+  newTypingAttrs[NSUnderlineColorAttributeName] = baseColor;
+  newTypingAttrs[NSStrikethroughColorAttributeName] = baseColor;
+  _input->textView.typingAttributes = newTypingAttrs;
 }
 
-#pragma mark - Detection
+#pragma mark - Main detection entry
+- (BOOL)styleConditionWithAttributes:(NSDictionary *)attrs
+                               range:(NSRange)range {
+  UIColor *color = attrs[NSForegroundColorAttributeName];
+  if (!color)
+    return NO;
 
--(BOOL)isInStyle:(NSRange) range styleType:(StyleType)styleType {
-  id<BaseStyleProtocol> style = _input->stylesDict[@(styleType)];
-  
-  return (range.length > 0
-          ? [style anyOccurence:range]
-          : [style detectStyle:range]);
+  if (color == _input->config.primaryColor)
+    return NO;
+
+  return ![self isColorUsedByAnotherStyle:color attributes:attrs range:range];
 }
 
-- (BOOL)isInCodeBlockAndHasTheSameColor:(id)value :(NSRange)range {
-  BOOL isInCodeBlock = [self isInStyle:range styleType: CodeBlock];
-  
-  return isInCodeBlock && [(UIColor *)value isEqualToColor:[_input->config codeBlockFgColor]];
-}
+- (BOOL)styleCondition:(id)value range:(NSRange)range {
+  if (!value)
+    return NO;
 
-- (BOOL)inLinkAndForegroundColorIsLinkColor:(id)value :(NSRange)range {
-  BOOL isInLink = [self isInStyle:range styleType: Link];
-  
-  return isInLink && [(UIColor *)value isEqualToColor:[_input->config linkColor]];
-}
+  NSTextStorage *ts = _input->textView.textStorage;
+  NSUInteger len = ts.length;
 
-- (BOOL)inInlineCodeAndHasTheSameColor:(id)value :(NSRange)range {
-  BOOL isInInlineCode = [self isInStyle:range styleType:InlineCode];
-  
-  return isInInlineCode && [(UIColor *)value isEqualToColor:[_input->config inlineCodeFgColor]];
-}
+  NSDictionary *attrs;
+  if (range.length == 0 || range.location >= len) {
+    attrs = _input->textView.typingAttributes;
+  } else {
+    NSUInteger loc = MIN(range.location, len - 1);
+    attrs = [ts attributesAtIndex:loc effectiveRange:nil];
+  }
 
-- (BOOL)inBlockQuoteAndHasTheSameColor:(id)value :(NSRange)range {
-  BOOL isInBlockQuote = [self isInStyle:range styleType:BlockQuote];
-  
-  return isInBlockQuote && [(UIColor *)value isEqualToColor:[_input->config blockquoteColor]];
-}
-
-- (BOOL)inMentionAndHasTheSameColor:(id)value :(NSRange)range {
-  MentionStyle *mentionStyle = _input->stylesDict[@(Mention)];
-  BOOL isInMention = [self isInStyle:range styleType:Mention];
-  
-  if (!isInMention) return NO;
-  
-  MentionParams *params = [mentionStyle getMentionParamsAt:range.location];
-  if (params == nil) return NO;
-  
-  MentionStyleProps *styleProps = [_input->config mentionStylePropsForIndicator:params.indicator];
-  
-  return [(UIColor *)value isEqualToColor:styleProps.color];
-}
-
-- (BOOL)styleCondition:(id)value :(NSRange)range {
-  if (value == nil) { return NO; }
-  
-  if ([(UIColor *)value isEqualToColor:_input->config.primaryColor]) { return NO; }
-  if ([self inBlockQuoteAndHasTheSameColor:value :range]) { return NO; }
-  if ([self inLinkAndForegroundColorIsLinkColor:value :range]) { return NO; }
-  if ([self inInlineCodeAndHasTheSameColor:value :range]) { return NO; }
-  if ([self inMentionAndHasTheSameColor:value :range]) { return NO; }
-  if ([self isInCodeBlockAndHasTheSameColor:value :range]) { return NO; }
-  
-  return YES;
+  return [self styleConditionWithAttributes:attrs range:range];
 }
 
 - (BOOL)detectStyle:(NSRange)range {
-  UIColor *color = [self getColorInRange:range];
-  
-  return [self detectStyle:range color:color];
-}
-
-- (BOOL)detectStyle:(NSRange)range color:(UIColor *)color {
-  if(range.length >= 1) {
-    return [OccurenceUtils detect:NSForegroundColorAttributeName withInput:_input inRange:range
-      withCondition: ^BOOL(id _Nullable value, NSRange range) {
-        return [(UIColor *)value isEqualToColor:color] && [self styleCondition:value :range];
-      }
-    ];
+  if (range.length >= 1) {
+    return [OccurenceUtils detect:NSForegroundColorAttributeName
+                        withInput:_input
+                          inRange:range
+                    withCondition:^BOOL(id _Nullable value, NSRange range) {
+                      return [self styleCondition:value range:range];
+                    }];
   } else {
-    return [OccurenceUtils detect:NSForegroundColorAttributeName withInput:_input atIndex:range.location checkPrevious:YES
-      withCondition:^BOOL(id _Nullable value, NSRange range) {
-        return [(UIColor *)value isEqualToColor:color] && [self styleCondition:value :range];
-      }
-    ];
+    id value =
+        _input->textView.typingAttributes[NSForegroundColorAttributeName];
+    return [self styleCondition:value range:range];
   }
 }
 
-- (BOOL)detectExcludingColor:(UIColor *)excludedColor inRange:(NSRange)range {
-    if (![self detectStyle:range]) {
-        return NO;
-    }
-    UIColor *currentColor = [self getColorInRange:range];
-    return currentColor != nil && ![currentColor isEqualToColor:excludedColor];
+- (BOOL)detectStyle:(NSRange)range color:(UIColor *)color {
+  if (range.length >= 1) {
+    return [OccurenceUtils detect:NSForegroundColorAttributeName
+                        withInput:_input
+                          inRange:range
+                    withCondition:^BOOL(id _Nullable value, NSRange range) {
+                      return [(UIColor *)value isEqualToColor:color] &&
+                             [self styleCondition:value range:range];
+                    }];
+  } else {
+    return [OccurenceUtils detect:NSForegroundColorAttributeName
+                        withInput:_input
+                          atIndex:range.location
+                    checkPrevious:NO
+                    withCondition:^BOOL(id _Nullable value, NSRange range) {
+                      return [(UIColor *)value isEqualToColor:color] &&
+                             [self styleCondition:value range:range];
+                    }];
+  }
 }
 
 - (BOOL)anyOccurence:(NSRange)range {
-  return [OccurenceUtils any:NSForegroundColorAttributeName withInput:_input inRange:range
-    withCondition:^BOOL(id _Nullable value, NSRange range) {
-      return [self styleCondition:value :range];
-    }
-  ];
+  return [OccurenceUtils any:NSForegroundColorAttributeName
+                   withInput:_input
+                     inRange:range
+               withCondition:^BOOL(id _Nullable value, NSRange range) {
+                 return [self styleCondition:value range:range];
+               }];
 }
 
 - (NSArray<StylePair *> *_Nullable)findAllOccurences:(NSRange)range {
-  return [OccurenceUtils all:NSForegroundColorAttributeName withInput:_input inRange:range
-    withCondition:^BOOL(id _Nullable value, NSRange range) {
-      return [self styleCondition:value :range];
-    }
-  ];
+  return [OccurenceUtils all:NSForegroundColorAttributeName
+                   withInput:_input
+                     inRange:range
+               withCondition:^BOOL(id _Nullable value, NSRange range) {
+                 return [self styleCondition:value range:range];
+               }];
+}
+
+- (void)addAttributes:(NSRange)range withTypingAttr:(BOOL)withTypingAttr {
+  [self addAttributes:range];
+}
+
+- (void)addAttributes:(NSRange)range {
+  // no-op
 }
 
 - (UIColor *)getColorAt:(NSUInteger)location {
   NSRange effectiveRange = NSMakeRange(0, 0);
   NSRange inputRange = NSMakeRange(0, _input->textView.textStorage.length);
-  
-  if(location == _input->textView.textStorage.length) {
-    UIColor *typingColor = _input->textView.typingAttributes[NSForegroundColorAttributeName];
+
+  if (location == _input->textView.textStorage.length) {
+    UIColor *typingColor =
+        _input->textView.typingAttributes[NSForegroundColorAttributeName];
     return typingColor ?: [_input->config primaryColor];
   }
-  
-  return [_input->textView.textStorage
-    attribute:NSForegroundColorAttributeName
-    atIndex:location
-    longestEffectiveRange: &effectiveRange
-    inRange:inputRange
-  ];
+
+  return [_input->textView.textStorage attribute:NSForegroundColorAttributeName
+                                         atIndex:location
+                           longestEffectiveRange:&effectiveRange
+                                         inRange:inputRange];
 }
 
 - (UIColor *)getColorInRange:(NSRange)range {
   NSUInteger location = range.location;
   NSUInteger length = range.length;
-  
+
   NSRange effectiveRange = NSMakeRange(0, 0);
   NSRange inputRange = NSMakeRange(0, _input->textView.textStorage.length);
-  
-  if(location == _input->textView.textStorage.length) {
-    UIColor *typingColor = _input->textView.typingAttributes[NSForegroundColorAttributeName];
+
+  if (location == _input->textView.textStorage.length) {
+    UIColor *typingColor =
+        _input->textView.typingAttributes[NSForegroundColorAttributeName];
     return typingColor ?: [_input->config primaryColor];
   }
-  
+
   NSUInteger queryLocation = location;
   if (length == 0 && location > 0) {
-      queryLocation = location - 1;
+    queryLocation = location - 1;
   }
-  
-  UIColor *color = [_input->textView.textStorage
-    attribute:NSForegroundColorAttributeName
-    atIndex:queryLocation
-    longestEffectiveRange: &effectiveRange
-    inRange:inputRange
-  ];
-  
+
+  UIColor *color =
+      [_input->textView.textStorage attribute:NSForegroundColorAttributeName
+                                      atIndex:queryLocation
+                        longestEffectiveRange:&effectiveRange
+                                      inRange:inputRange];
+
   return color;
 }
 
-- (UIColor *)baseColorForLocation:(NSUInteger)location {
-    BOOL inLink = [self isInStyle:NSMakeRange(location, 0) styleType:Link];
-    BOOL inInlineCode = [self isInStyle:NSMakeRange(location, 0) styleType:InlineCode];
-    BOOL inBlockQuote = [self isInStyle:NSMakeRange(location, 0) styleType:BlockQuote];
-    BOOL inMention = [self isInStyle:NSMakeRange(location, 0) styleType:Mention];
-    
-    UIColor *baseColor = [_input->config primaryColor];
-    if (inMention) {
-        MentionStyle *mentionStyle = _input->stylesDict[@(Mention)];
-        MentionParams *params = [mentionStyle getMentionParamsAt:location];
-        if (params != nil) {
-            MentionStyleProps *styleProps = [_input->config mentionStylePropsForIndicator:params.indicator];
-            baseColor = styleProps.color;
-        }
-    } else if (inLink) {
-        baseColor = [_input->config linkColor];
-    } else if (inInlineCode) {
-        baseColor = [_input->config inlineCodeFgColor];
-    } else if (inBlockQuote) {
-        baseColor = [_input->config blockquoteColor];
-    }
-    return baseColor;
+- (UIColor *)naturalColorForAttributes:(NSDictionary *)attrs
+                                 index:(NSUInteger)index {
+  for (NSNumber *num in self.coloredStyleTypes) {
+    UIColor *color = [self colorForStyle:(StyleType)num.integerValue
+                              attributes:attrs
+                                   index:index];
+    if (color)
+      return color;
+  }
+
+  return _input->config.primaryColor;
+}
+
+- (UIColor *)originalColorAtIndex:(NSUInteger)index {
+  NSTextStorage *ts = _input->textView.textStorage;
+  NSUInteger len = ts.length;
+
+  if (len == 0)
+    return _input->config.primaryColor;
+
+  if (index >= len)
+    index = len - 1;
+
+  NSDictionary *attrs = [ts attributesAtIndex:index effectiveRange:nil];
+
+  return [self naturalColorForAttributes:attrs index:index];
 }
 
 - (void)removeColorInSelectedRange {
   NSRange selectedRange = _input->textView.selectedRange;
-  
-  if(selectedRange.length > 0) {
-    [self removeAttributes: selectedRange];
+
+  if (selectedRange.length > 0) {
+    [self removeAttributes:selectedRange];
   } else {
     [self removeTypingAttributes];
+  }
+}
+
+- (BOOL)isColorUsedByAnotherStyle:(UIColor *)color
+                       attributes:(NSDictionary *)attrs
+                            range:(NSRange)range {
+  NSUInteger index = range.location;
+
+  for (NSNumber *num in self.coloredStyleTypes) {
+    UIColor *styleColor = [self colorForStyle:(StyleType)num.integerValue
+                                   attributes:attrs
+                                        index:index];
+
+    if (styleColor && [styleColor isEqual:color]) {
+      return YES;
+    }
+  }
+
+  return NO;
+}
+
+- (UIColor *)colorForStyle:(StyleType)type
+                attributes:(NSDictionary *)attrs
+                     index:(NSUInteger)index {
+  id<BaseStyleProtocol> style = _input->stylesDict[@(type)];
+  if (!style)
+    return nil;
+
+  NSAttributedStringKey key = [[style class] attributeKey];
+  id attr = attrs[key];
+  if (!attr || ![style styleCondition:attr range:NSMakeRange(index, 0)])
+    return nil;
+
+  InputConfig *config = _input->config;
+
+  switch (type) {
+  case Link:
+    return config.linkColor;
+
+  case InlineCode:
+    return config.inlineCodeFgColor;
+
+  case BlockQuote:
+    return config.blockquoteColor;
+
+  case CodeBlock:
+    return config.codeBlockFgColor;
+
+  case Mention: {
+    MentionParams *params = (MentionParams *)attr;
+    if (!params)
+      return nil;
+
+    MentionStyleProps *props =
+        [config mentionStylePropsForIndicator:params.indicator];
+    return props.color;
+  }
+
+  default:
+    return nil;
   }
 }
 

--- a/ios/styles/HeadingStyleBase.mm
+++ b/ios/styles/HeadingStyleBase.mm
@@ -10,6 +10,9 @@
 + (StyleType)getStyleType {
   return None;
 }
++ (NSAttributedStringKey)attributeKey {
+  return NSFontAttributeName;
+}
 - (CGFloat)getHeadingFontSize {
   return 0;
 }
@@ -100,7 +103,7 @@
                  options:0
               usingBlock:^(id _Nullable value, NSRange range,
                            BOOL *_Nonnull stop) {
-                if ([self styleCondition:value:range]) {
+                if ([self styleCondition:value range:range]) {
                   UIFont *newFont = [(UIFont *)value
                       setSize:[[[self typedInput]->config scaledPrimaryFontSize]
                                   floatValue]];
@@ -138,11 +141,10 @@
   // there as well
   [self removeAttributes:[self typedInput]->textView.selectedRange];
 }
-
 // when the traits already change, the getHeadginFontSize will return the new
 // font size and no headings would be properly detected, so that's why we have
 // to use the latest applied font size rather than that value.
-- (BOOL)styleCondition:(id _Nullable)value:(NSRange)range {
+- (BOOL)styleCondition:(id _Nullable)value range:(NSRange)range {
   UIFont *font = (UIFont *)value;
   if (font == nullptr) {
     return NO;
@@ -161,7 +163,7 @@
                         withInput:[self typedInput]
                           inRange:range
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   } else {
     return [OccurenceUtils detect:NSFontAttributeName
@@ -169,7 +171,7 @@
                           atIndex:range.location
                     checkPrevious:YES
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   }
 }
@@ -179,7 +181,7 @@
                    withInput:[self typedInput]
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 
@@ -188,7 +190,7 @@
                    withInput:[self typedInput]
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 

--- a/ios/styles/ImageStyle.mm
+++ b/ios/styles/ImageStyle.mm
@@ -20,6 +20,10 @@ static NSString *const ImageAttributeName = @"ImageAttributeName";
   return NO;
 }
 
++ (NSAttributedStringKey)attributeKey {
+  return ImageAttributeName;
+}
+
 - (instancetype)initWithInput:(id)input {
   self = [super init];
   _input = (EnrichedTextInputView *)input;
@@ -54,7 +58,7 @@ static NSString *const ImageAttributeName = @"ImageAttributeName";
   _input->textView.typingAttributes = currentAttributes;
 }
 
-- (BOOL)styleCondition:(id _Nullable)value:(NSRange)range {
+- (BOOL)styleCondition:(id _Nullable)value range:(NSRange)range {
   return [value isKindOfClass:[ImageData class]];
 }
 
@@ -63,7 +67,7 @@ static NSString *const ImageAttributeName = @"ImageAttributeName";
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 
@@ -73,7 +77,7 @@ static NSString *const ImageAttributeName = @"ImageAttributeName";
                         withInput:_input
                           inRange:range
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   } else {
     return [OccurenceUtils detect:ImageAttributeName
@@ -81,7 +85,7 @@ static NSString *const ImageAttributeName = @"ImageAttributeName";
                           atIndex:range.location
                     checkPrevious:YES
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   }
 }
@@ -91,7 +95,7 @@ static NSString *const ImageAttributeName = @"ImageAttributeName";
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 

--- a/ios/styles/InlineCodeStyle.mm
+++ b/ios/styles/InlineCodeStyle.mm
@@ -17,6 +17,10 @@
   return NO;
 }
 
++ (NSAttributedStringKey)attributeKey {
+  return NSBackgroundColorAttributeName;
+}
+
 - (instancetype)initWithInput:(id)input {
   self = [super init];
   _input = (EnrichedTextInputView *)input;
@@ -174,7 +178,7 @@
                                   atIndex:index
                            effectiveRange:nil];
 
-    if (bgColor != nil && [self styleCondition:bgColor:newlineRange]) {
+    if (bgColor != nil && [self styleCondition:bgColor range:newlineRange]) {
       [self removeAttributes:newlineRange];
     }
   }
@@ -182,7 +186,7 @@
 
 // emojis don't retain monospace font attribute so we check for the background
 // color if there is no mention
-- (BOOL)styleCondition:(id _Nullable)value:(NSRange)range {
+- (BOOL)styleCondition:(id _Nullable)value range:(NSRange)range {
   UIColor *bgColor = (UIColor *)value;
   MentionStyle *mStyle = _input->stylesDict[@([MentionStyle getStyleType])];
   return bgColor != nullptr && mStyle != nullptr && ![mStyle detectStyle:range];
@@ -205,7 +209,7 @@
                        withInput:_input
                          inRange:currentRange
                    withCondition:^BOOL(id _Nullable value, NSRange range) {
-                     return [self styleCondition:value:range];
+                     return [self styleCondition:value range:range];
                    }];
       detected = detected && currentDetected;
     }
@@ -217,7 +221,7 @@
                           atIndex:range.location
                     checkPrevious:NO
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   }
 }
@@ -227,7 +231,7 @@
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 
@@ -236,7 +240,7 @@
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 

--- a/ios/styles/ItalicStyle.mm
+++ b/ios/styles/ItalicStyle.mm
@@ -15,6 +15,10 @@
   return NO;
 }
 
++ (NSAttributedStringKey)attributeKey {
+  return NSFontAttributeName;
+}
+
 - (instancetype)initWithInput:(id)input {
   self = [super init];
   _input = (EnrichedTextInputView *)input;
@@ -91,7 +95,7 @@
   }
 }
 
-- (BOOL)styleCondition:(id _Nullable)value:(NSRange)range {
+- (BOOL)styleCondition:(id _Nullable)value range:(NSRange)range {
   UIFont *font = (UIFont *)value;
   return font != nullptr && [font isItalic];
 }
@@ -102,7 +106,7 @@
                         withInput:_input
                           inRange:range
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   } else {
     return [OccurenceUtils detect:NSFontAttributeName
@@ -110,7 +114,7 @@
                           atIndex:range.location
                     checkPrevious:NO
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   }
 }
@@ -120,7 +124,7 @@
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 
@@ -129,7 +133,7 @@
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 

--- a/ios/styles/MentionStyle.mm
+++ b/ios/styles/MentionStyle.mm
@@ -24,6 +24,10 @@ static NSString *const MentionAttributeName = @"MentionAttributeName";
   return NO;
 }
 
++ (NSAttributedStringKey)attributeKey {
+  return MentionAttributeName;
+}
+
 - (instancetype)initWithInput:(id)input {
   self = [super init];
   _input = (EnrichedTextInputView *)input;
@@ -136,7 +140,7 @@ static NSString *const MentionAttributeName = @"MentionAttributeName";
   _input->textView.typingAttributes = newTypingAttrs;
 }
 
-- (BOOL)styleCondition:(id _Nullable)value:(NSRange)range {
+- (BOOL)styleCondition:(id _Nullable)value range:(NSRange)range {
   MentionParams *params = (MentionParams *)value;
   return params != nullptr;
 }
@@ -147,7 +151,7 @@ static NSString *const MentionAttributeName = @"MentionAttributeName";
                         withInput:_input
                           inRange:range
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   } else {
     return [self getMentionParamsAt:range.location] != nullptr;
@@ -159,7 +163,7 @@ static NSString *const MentionAttributeName = @"MentionAttributeName";
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 
@@ -168,7 +172,7 @@ static NSString *const MentionAttributeName = @"MentionAttributeName";
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 

--- a/ios/styles/OrderedListStyle.mm
+++ b/ios/styles/OrderedListStyle.mm
@@ -17,6 +17,10 @@
   return YES;
 }
 
++ (NSAttributedStringKey)attributeKey {
+  return NSParagraphStyleAttributeName;
+}
+
 - (CGFloat)getHeadIndent {
   // lists are drawn manually
   // margin before marker + gap between marker and paragraph
@@ -235,7 +239,7 @@
   return NO;
 }
 
-- (BOOL)styleCondition:(id _Nullable)value:(NSRange)range {
+- (BOOL)styleCondition:(id _Nullable)value range:(NSRange)range {
   NSParagraphStyle *paragraph = (NSParagraphStyle *)value;
   return paragraph != nullptr && paragraph.textLists.count == 1 &&
          paragraph.textLists.firstObject.markerFormat ==
@@ -248,7 +252,7 @@
                         withInput:_input
                           inRange:range
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   } else {
     return [OccurenceUtils detect:NSParagraphStyleAttributeName
@@ -256,7 +260,7 @@
                           atIndex:range.location
                     checkPrevious:YES
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   }
 }
@@ -266,7 +270,7 @@
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 
@@ -275,7 +279,7 @@
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 

--- a/ios/styles/StrikethroughStyle.mm
+++ b/ios/styles/StrikethroughStyle.mm
@@ -14,6 +14,10 @@
   return NO;
 }
 
++ (NSAttributedStringKey)attributeKey {
+  return NSStrikethroughStyleAttributeName;
+}
+
 - (instancetype)initWithInput:(id)input {
   self = [super init];
   _input = (EnrichedTextInputView *)input;
@@ -56,7 +60,7 @@
   _input->textView.typingAttributes = newTypingAttrs;
 }
 
-- (BOOL)styleCondition:(id _Nullable)value:(NSRange)range {
+- (BOOL)styleCondition:(id _Nullable)value range:(NSRange)range {
   NSNumber *strikethroughStyle = (NSNumber *)value;
   return strikethroughStyle != nullptr &&
          [strikethroughStyle intValue] != NSUnderlineStyleNone;
@@ -68,7 +72,7 @@
                         withInput:_input
                           inRange:range
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   } else {
     return [OccurenceUtils detect:NSStrikethroughStyleAttributeName
@@ -76,7 +80,7 @@
                           atIndex:range.location
                     checkPrevious:NO
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   }
 }
@@ -86,7 +90,7 @@
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 
@@ -95,7 +99,7 @@
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 

--- a/ios/styles/UnderlineStyle.mm
+++ b/ios/styles/UnderlineStyle.mm
@@ -14,6 +14,10 @@
   return NO;
 }
 
++ (NSAttributedStringKey)attributeKey {
+  return NSUnderlineStyleAttributeName;
+}
+
 - (instancetype)initWithInput:(id)input {
   self = [super init];
   _input = (EnrichedTextInputView *)input;
@@ -91,7 +95,7 @@
   return conflicted;
 }
 
-- (BOOL)styleCondition:(id _Nullable)value:(NSRange)range {
+- (BOOL)styleCondition:(id _Nullable)value range:(NSRange)range {
   NSNumber *underlineStyle = (NSNumber *)value;
   return underlineStyle != nullptr &&
          [underlineStyle intValue] != NSUnderlineStyleNone &&
@@ -105,7 +109,7 @@
                         withInput:_input
                           inRange:range
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   } else {
     return [OccurenceUtils detect:NSUnderlineStyleAttributeName
@@ -113,7 +117,7 @@
                           atIndex:range.location
                     checkPrevious:NO
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   }
 }
@@ -123,7 +127,7 @@
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 
@@ -132,7 +136,7 @@
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 

--- a/ios/styles/UnorderedListStyle.mm
+++ b/ios/styles/UnorderedListStyle.mm
@@ -17,6 +17,10 @@
   return YES;
 }
 
++ (NSAttributedStringKey)attributeKey {
+  return NSParagraphStyleAttributeName;
+}
+
 - (CGFloat)getHeadIndent {
   // lists are drawn manually
   // margin before bullet + gap between bullet and paragraph
@@ -234,7 +238,7 @@
   return NO;
 }
 
-- (BOOL)styleCondition:(id _Nullable)value:(NSRange)range {
+- (BOOL)styleCondition:(id _Nullable)value range:(NSRange)range {
   NSParagraphStyle *paragraph = (NSParagraphStyle *)value;
   return paragraph != nullptr && paragraph.textLists.count == 1 &&
          paragraph.textLists.firstObject.markerFormat == NSTextListMarkerDisc;
@@ -246,7 +250,7 @@
                         withInput:_input
                           inRange:range
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   } else {
     return [OccurenceUtils detect:NSParagraphStyleAttributeName
@@ -254,7 +258,7 @@
                           atIndex:range.location
                     checkPrevious:YES
                     withCondition:^BOOL(id _Nullable value, NSRange range) {
-                      return [self styleCondition:value:range];
+                      return [self styleCondition:value range:range];
                     }];
   }
 }
@@ -264,7 +268,7 @@
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 
@@ -273,7 +277,7 @@
                    withInput:_input
                      inRange:range
                withCondition:^BOOL(id _Nullable value, NSRange range) {
-                 return [self styleCondition:value:range];
+                 return [self styleCondition:value range:range];
                }];
 }
 

--- a/ios/utils/BaseStyleProtocol.h
+++ b/ios/utils/BaseStyleProtocol.h
@@ -5,6 +5,8 @@
 @protocol BaseStyleProtocol <NSObject>
 + (StyleType)getStyleType;
 + (BOOL)isParagraphStyle;
++ (NSAttributedStringKey _Nonnull)attributeKey;
+- (BOOL)styleCondition:(id _Nullable)value range:(NSRange)range;
 - (instancetype _Nonnull)initWithInput:(id _Nonnull)input;
 - (void)applyStyle:(NSRange)range;
 - (void)addAttributes:(NSRange)range withTypingAttr:(BOOL)withTypingAttr;

--- a/ios/utils/ColorExtension.h
+++ b/ios/utils/ColorExtension.h
@@ -5,3 +5,11 @@
 - (BOOL)isEqualToColor:(UIColor *)otherColor;
 - (UIColor *)colorWithAlphaIfNotTransparent:(CGFloat)newAlpha;
 @end
+
+@interface UIColor (FromString)
++ (UIColor *)colorFromString:(NSString *)string;
+@end
+
+@interface UIColor (HexString)
+- (NSString *)hexString;
+@end

--- a/ios/utils/ColorExtension.mm
+++ b/ios/utils/ColorExtension.mm
@@ -36,3 +36,157 @@
   return self;
 }
 @end
+
+@implementation UIColor (FromString)
++ (UIColor *)colorFromString:(NSString *)string {
+    if (!string) return nil;
+    
+    NSString *input = [[string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
+    
+    // Expanded named colors (add more from CSS list as needed)
+    NSDictionary *namedColors = @{
+        @"red": [UIColor redColor],
+        @"green": [UIColor greenColor],
+        @"blue": [UIColor blueColor],
+        @"black": [UIColor blackColor],
+        @"white": [UIColor whiteColor],
+        @"yellow": [UIColor yellowColor],
+        @"gray": [UIColor grayColor],
+        @"grey": [UIColor grayColor],
+        @"transparent": [UIColor clearColor],
+        @"aliceblue": [UIColor colorWithRed:0.941 green:0.973 blue:1.0 alpha:1.0],
+        // Add additional CSS names here, e.g., "chartreuse": [UIColor colorWithRed:0.498 green:1.0 blue:0.0 alpha:1.0],
+    };
+    
+    UIColor *namedColor = namedColors[input];
+    if (namedColor) return namedColor;
+    
+    // Hex parsing (including short forms)
+    if ([input hasPrefix:@"#"]) {
+        NSString *hex = [input substringFromIndex:1];
+        if (hex.length == 3 || hex.length == 4) { // Short hex: #rgb or #rgba
+            NSMutableString *expanded = [NSMutableString string];
+            for (NSUInteger i = 0; i < hex.length; i++) {
+                unichar c = [hex characterAtIndex:i];
+                [expanded appendFormat:@"%c%c", c, c];
+            }
+            hex = expanded;
+        }
+        if (hex.length == 6 || hex.length == 8) {
+            unsigned int hexValue = 0;
+            NSScanner *scanner = [NSScanner scannerWithString:hex];
+            if ([scanner scanHexInt:&hexValue]) {
+                CGFloat r, g, b, a = 1.0;
+                if (hex.length == 6) {
+                    r = ((hexValue & 0xFF0000) >> 16) / 255.0;
+                    g = ((hexValue & 0x00FF00) >> 8) / 255.0;
+                    b = (hexValue & 0x0000FF) / 255.0;
+                } else {
+                    r = ((hexValue & 0xFF000000) >> 24) / 255.0;
+                    g = ((hexValue & 0x00FF0000) >> 16) / 255.0;
+                    b = ((hexValue & 0x0000FF00) >> 8) / 255.0;
+                    a = (hexValue & 0x000000FF) / 255.0;
+                }
+                return [UIColor colorWithRed:r green:g blue:b alpha:a];
+            }
+        }
+        return nil;
+    }
+    
+    // RGB/RGBA parsing (with percentages)
+    if ([input hasPrefix:@"rgb"] || [input hasPrefix:@"rgba"]) {
+        NSString *clean = [input stringByReplacingOccurrencesOfString:@"rgb" withString:@""];
+        clean = [clean stringByReplacingOccurrencesOfString:@"a" withString:@""];
+        clean = [clean stringByReplacingOccurrencesOfString:@"(" withString:@""];
+        clean = [clean stringByReplacingOccurrencesOfString:@")" withString:@""];
+        clean = [clean stringByReplacingOccurrencesOfString:@" " withString:@""];
+        
+        NSArray<NSString *> *parts = [clean componentsSeparatedByString:@","];
+        if (parts.count == 3 || parts.count == 4) {
+            CGFloat r = [self parseColorComponent:parts[0] max:255.0];
+            CGFloat g = [self parseColorComponent:parts[1] max:255.0];
+            CGFloat b = [self parseColorComponent:parts[2] max:255.0];
+            CGFloat a = parts.count == 4 ? [self parseColorComponent:parts[3] max:1.0] : 1.0;
+            if (r >= 0 && g >= 0 && b >= 0 && a >= 0) {
+                return [UIColor colorWithRed:r green:g blue:b alpha:a];
+            }
+        }
+        return nil;
+    }
+    
+    // HSL/HSLA parsing (basic implementation)
+    if ([input hasPrefix:@"hsl"] || [input hasPrefix:@"hsla"]) {
+        NSString *clean = [input stringByReplacingOccurrencesOfString:@"hsl" withString:@""];
+        clean = [clean stringByReplacingOccurrencesOfString:@"a" withString:@""];
+        clean = [clean stringByReplacingOccurrencesOfString:@"(" withString:@""];
+        clean = [clean stringByReplacingOccurrencesOfString:@")" withString:@""];
+        clean = [clean stringByReplacingOccurrencesOfString:@" " withString:@""];
+        
+        NSArray<NSString *> *parts = [clean componentsSeparatedByString:@","];
+        if (parts.count == 3 || parts.count == 4) {
+            CGFloat h = [self parseColorComponent:parts[0] max:360.0];
+            CGFloat s = [self parseColorComponent:parts[1] max:1.0];
+            CGFloat l = [self parseColorComponent:parts[2] max:1.0];
+            CGFloat a = parts.count == 4 ? [self parseColorComponent:parts[3] max:1.0] : 1.0;
+            return [UIColor colorWithHue:h / 360.0 saturation:s brightness:l alpha:a]; // Note: Uses HSB approximation
+        }
+        return nil;
+    }
+    
+    return nil;
+}
+
++ (CGFloat)parseColorComponent:(NSString *)comp max:(CGFloat)max {
+    if ([comp hasSuffix:@"%"]) {
+        comp = [comp stringByReplacingOccurrencesOfString:@"%" withString:@""];
+        return [comp floatValue] / 100.0;
+    }
+    return [comp floatValue] / max;
+}
+@end
+
+@implementation UIColor (HexString)
+- (NSString *)hexString {
+    CGColorRef colorRef = self.CGColor;
+    size_t numComponents = CGColorGetNumberOfComponents(colorRef);
+    const CGFloat *components = CGColorGetComponents(colorRef);
+    
+    CGFloat r = 0.0, g = 0.0, b = 0.0, a = 1.0;
+    
+    if (numComponents == 2) { // Monochrome (grayscale)
+        r = components[0];
+        g = components[0];
+        b = components[0];
+        a = components[1];
+    } else if (numComponents == 4) { // RGBA
+        r = components[0];
+        g = components[1];
+        b = components[2];
+        a = components[3];
+    } else if (numComponents == 3) { // RGB (no alpha)
+        r = components[0];
+        g = components[1];
+        b = components[2];
+    } else {
+        // Unsupported color space (e.g., pattern colors)
+        return @"#FFFFFF"; // Or return nil for better error handling
+    }
+    
+    int red = (int)lroundf(r * 255.0f);
+    int green = (int)lroundf(g * 255.0f);
+    int blue = (int)lroundf(b * 255.0f);
+    int alpha = (int)lroundf(a * 255.0f);
+    
+    // Clamp values to 0-255 to prevent overflow
+    red = MAX(0, MIN(255, red));
+    green = MAX(0, MIN(255, green));
+    blue = MAX(0, MIN(255, blue));
+    alpha = MAX(0, MIN(255, alpha));
+    
+    if (alpha < 255) {
+        return [NSString stringWithFormat:@"#%02X%02X%02X%02X", red, green, blue, alpha];
+    } else {
+        return [NSString stringWithFormat:@"#%02X%02X%02X", red, green, blue];
+    }
+}
+@end

--- a/ios/utils/ColorExtension.mm
+++ b/ios/utils/ColorExtension.mm
@@ -55,7 +55,6 @@
         @"grey": [UIColor grayColor],
         @"transparent": [UIColor clearColor],
         @"aliceblue": [UIColor colorWithRed:0.941 green:0.973 blue:1.0 alpha:1.0],
-        // Add additional CSS names here, e.g., "chartreuse": [UIColor colorWithRed:0.498 green:1.0 blue:0.0 alpha:1.0],
     };
     
     UIColor *namedColor = namedColors[input];
@@ -169,7 +168,7 @@
         b = components[2];
     } else {
         // Unsupported color space (e.g., pattern colors)
-        return @"#FFFFFF"; // Or return nil for better error handling
+        return @"#FFFFFF";
     }
     
     int red = (int)lroundf(r * 255.0f);

--- a/ios/utils/ColorExtension.mm
+++ b/ios/utils/ColorExtension.mm
@@ -39,153 +39,166 @@
 
 @implementation UIColor (FromString)
 + (UIColor *)colorFromString:(NSString *)string {
-    if (!string) return nil;
-    
-    NSString *input = [[string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
-    
-    // Expanded named colors (add more from CSS list as needed)
-    NSDictionary *namedColors = @{
-        @"red": [UIColor redColor],
-        @"green": [UIColor greenColor],
-        @"blue": [UIColor blueColor],
-        @"black": [UIColor blackColor],
-        @"white": [UIColor whiteColor],
-        @"yellow": [UIColor yellowColor],
-        @"gray": [UIColor grayColor],
-        @"grey": [UIColor grayColor],
-        @"transparent": [UIColor clearColor],
-        @"aliceblue": [UIColor colorWithRed:0.941 green:0.973 blue:1.0 alpha:1.0],
-    };
-    
-    UIColor *namedColor = namedColors[input];
-    if (namedColor) return namedColor;
-    
-    // Hex parsing (including short forms)
-    if ([input hasPrefix:@"#"]) {
-        NSString *hex = [input substringFromIndex:1];
-        if (hex.length == 3 || hex.length == 4) { // Short hex: #rgb or #rgba
-            NSMutableString *expanded = [NSMutableString string];
-            for (NSUInteger i = 0; i < hex.length; i++) {
-                unichar c = [hex characterAtIndex:i];
-                [expanded appendFormat:@"%c%c", c, c];
-            }
-            hex = expanded;
-        }
-        if (hex.length == 6 || hex.length == 8) {
-            unsigned int hexValue = 0;
-            NSScanner *scanner = [NSScanner scannerWithString:hex];
-            if ([scanner scanHexInt:&hexValue]) {
-                CGFloat r, g, b, a = 1.0;
-                if (hex.length == 6) {
-                    r = ((hexValue & 0xFF0000) >> 16) / 255.0;
-                    g = ((hexValue & 0x00FF00) >> 8) / 255.0;
-                    b = (hexValue & 0x0000FF) / 255.0;
-                } else {
-                    r = ((hexValue & 0xFF000000) >> 24) / 255.0;
-                    g = ((hexValue & 0x00FF0000) >> 16) / 255.0;
-                    b = ((hexValue & 0x0000FF00) >> 8) / 255.0;
-                    a = (hexValue & 0x000000FF) / 255.0;
-                }
-                return [UIColor colorWithRed:r green:g blue:b alpha:a];
-            }
-        }
-        return nil;
-    }
-    
-    // RGB/RGBA parsing (with percentages)
-    if ([input hasPrefix:@"rgb"] || [input hasPrefix:@"rgba"]) {
-        NSString *clean = [input stringByReplacingOccurrencesOfString:@"rgb" withString:@""];
-        clean = [clean stringByReplacingOccurrencesOfString:@"a" withString:@""];
-        clean = [clean stringByReplacingOccurrencesOfString:@"(" withString:@""];
-        clean = [clean stringByReplacingOccurrencesOfString:@")" withString:@""];
-        clean = [clean stringByReplacingOccurrencesOfString:@" " withString:@""];
-        
-        NSArray<NSString *> *parts = [clean componentsSeparatedByString:@","];
-        if (parts.count == 3 || parts.count == 4) {
-            CGFloat r = [self parseColorComponent:parts[0] max:255.0];
-            CGFloat g = [self parseColorComponent:parts[1] max:255.0];
-            CGFloat b = [self parseColorComponent:parts[2] max:255.0];
-            CGFloat a = parts.count == 4 ? [self parseColorComponent:parts[3] max:1.0] : 1.0;
-            if (r >= 0 && g >= 0 && b >= 0 && a >= 0) {
-                return [UIColor colorWithRed:r green:g blue:b alpha:a];
-            }
-        }
-        return nil;
-    }
-    
-    // HSL/HSLA parsing (basic implementation)
-    if ([input hasPrefix:@"hsl"] || [input hasPrefix:@"hsla"]) {
-        NSString *clean = [input stringByReplacingOccurrencesOfString:@"hsl" withString:@""];
-        clean = [clean stringByReplacingOccurrencesOfString:@"a" withString:@""];
-        clean = [clean stringByReplacingOccurrencesOfString:@"(" withString:@""];
-        clean = [clean stringByReplacingOccurrencesOfString:@")" withString:@""];
-        clean = [clean stringByReplacingOccurrencesOfString:@" " withString:@""];
-        
-        NSArray<NSString *> *parts = [clean componentsSeparatedByString:@","];
-        if (parts.count == 3 || parts.count == 4) {
-            CGFloat h = [self parseColorComponent:parts[0] max:360.0];
-            CGFloat s = [self parseColorComponent:parts[1] max:1.0];
-            CGFloat l = [self parseColorComponent:parts[2] max:1.0];
-            CGFloat a = parts.count == 4 ? [self parseColorComponent:parts[3] max:1.0] : 1.0;
-            return [UIColor colorWithHue:h / 360.0 saturation:s brightness:l alpha:a]; // Note: Uses HSB approximation
-        }
-        return nil;
-    }
-    
+  if (!string)
     return nil;
+
+  NSString *input = [[string
+      stringByTrimmingCharactersInSet:[NSCharacterSet
+                                          whitespaceAndNewlineCharacterSet]]
+      lowercaseString];
+
+  // Expanded named colors (add more from CSS list as needed)
+  NSDictionary *namedColors = @{
+    @"red" : [UIColor redColor],
+    @"green" : [UIColor greenColor],
+    @"blue" : [UIColor blueColor],
+    @"black" : [UIColor blackColor],
+    @"white" : [UIColor whiteColor],
+    @"yellow" : [UIColor yellowColor],
+    @"gray" : [UIColor grayColor],
+    @"grey" : [UIColor grayColor],
+    @"transparent" : [UIColor clearColor],
+    @"aliceblue" : [UIColor colorWithRed:0.941 green:0.973 blue:1.0 alpha:1.0],
+  };
+
+  UIColor *namedColor = namedColors[input];
+  if (namedColor)
+    return namedColor;
+
+  // Hex parsing (including short forms)
+  if ([input hasPrefix:@"#"]) {
+    NSString *hex = [input substringFromIndex:1];
+    if (hex.length == 3 || hex.length == 4) { // Short hex: #rgb or #rgba
+      NSMutableString *expanded = [NSMutableString string];
+      for (NSUInteger i = 0; i < hex.length; i++) {
+        unichar c = [hex characterAtIndex:i];
+        [expanded appendFormat:@"%c%c", c, c];
+      }
+      hex = expanded;
+    }
+    if (hex.length == 6 || hex.length == 8) {
+      unsigned int hexValue = 0;
+      NSScanner *scanner = [NSScanner scannerWithString:hex];
+      if ([scanner scanHexInt:&hexValue]) {
+        CGFloat r, g, b, a = 1.0;
+        if (hex.length == 6) {
+          r = ((hexValue & 0xFF0000) >> 16) / 255.0;
+          g = ((hexValue & 0x00FF00) >> 8) / 255.0;
+          b = (hexValue & 0x0000FF) / 255.0;
+        } else {
+          r = ((hexValue & 0xFF000000) >> 24) / 255.0;
+          g = ((hexValue & 0x00FF0000) >> 16) / 255.0;
+          b = ((hexValue & 0x0000FF00) >> 8) / 255.0;
+          a = (hexValue & 0x000000FF) / 255.0;
+        }
+        return [UIColor colorWithRed:r green:g blue:b alpha:a];
+      }
+    }
+    return nil;
+  }
+
+  // RGB/RGBA parsing (with percentages)
+  if ([input hasPrefix:@"rgb"] || [input hasPrefix:@"rgba"]) {
+    NSString *clean = [input stringByReplacingOccurrencesOfString:@"rgb"
+                                                       withString:@""];
+    clean = [clean stringByReplacingOccurrencesOfString:@"a" withString:@""];
+    clean = [clean stringByReplacingOccurrencesOfString:@"(" withString:@""];
+    clean = [clean stringByReplacingOccurrencesOfString:@")" withString:@""];
+    clean = [clean stringByReplacingOccurrencesOfString:@" " withString:@""];
+
+    NSArray<NSString *> *parts = [clean componentsSeparatedByString:@","];
+    if (parts.count == 3 || parts.count == 4) {
+      CGFloat r = [self parseColorComponent:parts[0] max:255.0];
+      CGFloat g = [self parseColorComponent:parts[1] max:255.0];
+      CGFloat b = [self parseColorComponent:parts[2] max:255.0];
+      CGFloat a =
+          parts.count == 4 ? [self parseColorComponent:parts[3] max:1.0] : 1.0;
+      if (r >= 0 && g >= 0 && b >= 0 && a >= 0) {
+        return [UIColor colorWithRed:r green:g blue:b alpha:a];
+      }
+    }
+    return nil;
+  }
+
+  // HSL/HSLA parsing (basic implementation)
+  if ([input hasPrefix:@"hsl"] || [input hasPrefix:@"hsla"]) {
+    NSString *clean = [input stringByReplacingOccurrencesOfString:@"hsl"
+                                                       withString:@""];
+    clean = [clean stringByReplacingOccurrencesOfString:@"a" withString:@""];
+    clean = [clean stringByReplacingOccurrencesOfString:@"(" withString:@""];
+    clean = [clean stringByReplacingOccurrencesOfString:@")" withString:@""];
+    clean = [clean stringByReplacingOccurrencesOfString:@" " withString:@""];
+
+    NSArray<NSString *> *parts = [clean componentsSeparatedByString:@","];
+    if (parts.count == 3 || parts.count == 4) {
+      CGFloat h = [self parseColorComponent:parts[0] max:360.0];
+      CGFloat s = [self parseColorComponent:parts[1] max:1.0];
+      CGFloat l = [self parseColorComponent:parts[2] max:1.0];
+      CGFloat a =
+          parts.count == 4 ? [self parseColorComponent:parts[3] max:1.0] : 1.0;
+      return [UIColor colorWithHue:h / 360.0
+                        saturation:s
+                        brightness:l
+                             alpha:a]; // Note: Uses HSB approximation
+    }
+    return nil;
+  }
+
+  return nil;
 }
 
 + (CGFloat)parseColorComponent:(NSString *)comp max:(CGFloat)max {
-    if ([comp hasSuffix:@"%"]) {
-        comp = [comp stringByReplacingOccurrencesOfString:@"%" withString:@""];
-        return [comp floatValue] / 100.0;
-    }
-    return [comp floatValue] / max;
+  if ([comp hasSuffix:@"%"]) {
+    comp = [comp stringByReplacingOccurrencesOfString:@"%" withString:@""];
+    return [comp floatValue] / 100.0;
+  }
+  return [comp floatValue] / max;
 }
 @end
 
 @implementation UIColor (HexString)
 - (NSString *)hexString {
-    CGColorRef colorRef = self.CGColor;
-    size_t numComponents = CGColorGetNumberOfComponents(colorRef);
-    const CGFloat *components = CGColorGetComponents(colorRef);
-    
-    CGFloat r = 0.0, g = 0.0, b = 0.0, a = 1.0;
-    
-    if (numComponents == 2) { // Monochrome (grayscale)
-        r = components[0];
-        g = components[0];
-        b = components[0];
-        a = components[1];
-    } else if (numComponents == 4) { // RGBA
-        r = components[0];
-        g = components[1];
-        b = components[2];
-        a = components[3];
-    } else if (numComponents == 3) { // RGB (no alpha)
-        r = components[0];
-        g = components[1];
-        b = components[2];
-    } else {
-        // Unsupported color space (e.g., pattern colors)
-        return @"#FFFFFF";
-    }
-    
-    int red = (int)lroundf(r * 255.0f);
-    int green = (int)lroundf(g * 255.0f);
-    int blue = (int)lroundf(b * 255.0f);
-    int alpha = (int)lroundf(a * 255.0f);
-    
-    // Clamp values to 0-255 to prevent overflow
-    red = MAX(0, MIN(255, red));
-    green = MAX(0, MIN(255, green));
-    blue = MAX(0, MIN(255, blue));
-    alpha = MAX(0, MIN(255, alpha));
-    
-    if (alpha < 255) {
-        return [NSString stringWithFormat:@"#%02X%02X%02X%02X", red, green, blue, alpha];
-    } else {
-        return [NSString stringWithFormat:@"#%02X%02X%02X", red, green, blue];
-    }
+  CGColorRef colorRef = self.CGColor;
+  size_t numComponents = CGColorGetNumberOfComponents(colorRef);
+  const CGFloat *components = CGColorGetComponents(colorRef);
+
+  CGFloat r = 0.0, g = 0.0, b = 0.0, a = 1.0;
+
+  if (numComponents == 2) { // Monochrome (grayscale)
+    r = components[0];
+    g = components[0];
+    b = components[0];
+    a = components[1];
+  } else if (numComponents == 4) { // RGBA
+    r = components[0];
+    g = components[1];
+    b = components[2];
+    a = components[3];
+  } else if (numComponents == 3) { // RGB (no alpha)
+    r = components[0];
+    g = components[1];
+    b = components[2];
+  } else {
+    // Unsupported color space (e.g., pattern colors)
+    return @"#FFFFFF";
+  }
+
+  int red = (int)lroundf(r * 255.0f);
+  int green = (int)lroundf(g * 255.0f);
+  int blue = (int)lroundf(b * 255.0f);
+  int alpha = (int)lroundf(a * 255.0f);
+
+  // Clamp values to 0-255 to prevent overflow
+  red = MAX(0, MIN(255, red));
+  green = MAX(0, MIN(255, green));
+  blue = MAX(0, MIN(255, blue));
+  alpha = MAX(0, MIN(255, alpha));
+
+  if (alpha < 255) {
+    return [NSString
+        stringWithFormat:@"#%02X%02X%02X%02X", red, green, blue, alpha];
+  } else {
+    return [NSString stringWithFormat:@"#%02X%02X%02X", red, green, blue];
+  }
 }
 @end

--- a/ios/utils/ColorUtils.m
+++ b/ios/utils/ColorUtils.m
@@ -1,0 +1,8 @@
+//
+//  ColorUtils.m
+//  ReactNativeEnriched
+//
+//  Created by Ivan Ignathuk on 19/11/2025.
+//
+
+#import <Foundation/Foundation.h>

--- a/ios/utils/ColorUtils.m
+++ b/ios/utils/ColorUtils.m
@@ -1,8 +1,0 @@
-//
-//  ColorUtils.m
-//  ReactNativeEnriched
-//
-//  Created by Ivan Ignathuk on 19/11/2025.
-//
-
-#import <Foundation/Foundation.h>

--- a/ios/utils/StyleHeaders.h
+++ b/ios/utils/StyleHeaders.h
@@ -20,6 +20,13 @@
 - (void)handleNewlines;
 @end
 
+@interface ColorStyle : NSObject <BaseStyleProtocol>
+@property (nonatomic, strong) UIColor *color;
+- (UIColor *)getColorAt:(NSUInteger)location;
+- (void)applyStyle:(NSRange)range color:(UIColor *)color;
+- (BOOL)detectExcludingColor:(UIColor *)excludedColor inRange:(NSRange)range;
+@end
+
 @interface LinkStyle : NSObject <BaseStyleProtocol>
 - (void)addLink:(NSString *)text
               url:(NSString *)url

--- a/ios/utils/StyleHeaders.h
+++ b/ios/utils/StyleHeaders.h
@@ -21,10 +21,9 @@
 @end
 
 @interface ColorStyle : NSObject <BaseStyleProtocol>
-@property (nonatomic, strong) UIColor *color;
+@property(nonatomic, strong) UIColor *color;
 - (UIColor *)getColorAt:(NSUInteger)location;
 - (void)applyStyle:(NSRange)range color:(UIColor *)color;
-- (BOOL)detectExcludingColor:(UIColor *)excludedColor inRange:(NSRange)range;
 - (void)removeColorInSelectedRange;
 @end
 

--- a/ios/utils/StyleHeaders.h
+++ b/ios/utils/StyleHeaders.h
@@ -25,6 +25,7 @@
 - (UIColor *)getColorAt:(NSUInteger)location;
 - (void)applyStyle:(NSRange)range color:(UIColor *)color;
 - (BOOL)detectExcludingColor:(UIColor *)excludedColor inRange:(NSRange)range;
+- (void)removeColorInSelectedRange;
 @end
 
 @interface LinkStyle : NSObject <BaseStyleProtocol>

--- a/ios/utils/StyleTypeEnum.h
+++ b/ios/utils/StyleTypeEnum.h
@@ -21,5 +21,6 @@ typedef NS_ENUM(NSInteger, StyleType) {
   Italic,
   Underline,
   Strikethrough,
+  Colored,
   None,
 };

--- a/src/EnrichedTextInput.tsx
+++ b/src/EnrichedTextInput.tsx
@@ -69,7 +69,8 @@ export interface EnrichedTextInputInstance extends NativeMethods {
     text: string,
     attributes?: Record<string, string>
   ) => void;
-  toggleColor: (color: string) => void;
+  setColor: (color: string) => void;
+  removeColor: () => void;
 }
 
 export interface OnChangeMentionEvent {
@@ -358,8 +359,11 @@ export const EnrichedTextInput = ({
     setSelection: (start: number, end: number) => {
       Commands.setSelection(nullthrows(nativeRef.current), start, end);
     },
-    toggleColor: (color: string) => {
-      Commands.toggleColor(nullthrows(nativeRef.current), color);
+    setColor: (color: string) => {
+      Commands.setColor(nullthrows(nativeRef.current), color);
+    },
+    removeColor: () => {
+      Commands.removeColor(nullthrows(nativeRef.current));
     },
   }));
 

--- a/src/EnrichedTextInput.tsx
+++ b/src/EnrichedTextInput.tsx
@@ -20,6 +20,7 @@ import EnrichedTextInputNativeComponent, {
   type OnRequestHtmlResultEvent,
   type MentionStyleProperties,
   type OnChangeStateDeprecatedEvent,
+  type OnChangeColorEvent,
 } from './EnrichedTextInputNativeComponent';
 import type {
   ColorValue,
@@ -68,6 +69,7 @@ export interface EnrichedTextInputInstance extends NativeMethods {
     text: string,
     attributes?: Record<string, string>
   ) => void;
+  toggleColor: (color: string) => void;
 }
 
 export interface OnChangeMentionEvent {
@@ -153,6 +155,9 @@ export interface EnrichedTextInputProps extends Omit<ViewProps, 'children'> {
   onChangeMention?: (e: OnChangeMentionEvent) => void;
   onEndMention?: (indicator: string) => void;
   onChangeSelection?: (e: NativeSyntheticEvent<OnChangeSelectionEvent>) => void;
+  onColorChangeInSelection?: (
+    color: NativeSyntheticEvent<OnChangeColorEvent>
+  ) => void;
   /**
    * If true, Android will use experimental synchronous events.
    * This will prevent from input flickering when updating component size.
@@ -210,6 +215,7 @@ export const EnrichedTextInput = ({
   onChangeMention,
   onEndMention,
   onChangeSelection,
+  onColorChangeInSelection,
   androidExperimentalSynchronousEvents = false,
   scrollEnabled = true,
   ...rest
@@ -352,6 +358,9 @@ export const EnrichedTextInput = ({
     setSelection: (start: number, end: number) => {
       Commands.setSelection(nullthrows(nativeRef.current), start, end);
     },
+    toggleColor: (color: string) => {
+      Commands.toggleColor(nullthrows(nativeRef.current), color);
+    },
   }));
 
   const handleMentionEvent = (e: NativeSyntheticEvent<OnMentionEvent>) => {
@@ -426,6 +435,7 @@ export const EnrichedTextInput = ({
       onMention={handleMentionEvent}
       onChangeSelection={onChangeSelection}
       onRequestHtmlResult={handleRequestHtmlResult}
+      onColorChangeInSelection={onColorChangeInSelection}
       androidExperimentalSynchronousEvents={
         androidExperimentalSynchronousEvents
       }

--- a/src/EnrichedTextInputNativeComponent.ts
+++ b/src/EnrichedTextInputNativeComponent.ts
@@ -32,6 +32,11 @@ export interface OnChangeStateEvent {
     isConflicting: boolean;
     isBlocking: boolean;
   };
+  colored: {
+    isActive: boolean;
+    isConflicting: boolean;
+    isBlocking: boolean;
+  };
   italic: {
     isActive: boolean;
     isConflicting: boolean;
@@ -138,6 +143,7 @@ export interface OnChangeStateDeprecatedEvent {
   isLink: boolean;
   isImage: boolean;
   isMention: boolean;
+  isColored: boolean;
 }
 
 export interface OnLinkDetected {
@@ -185,6 +191,10 @@ type Heading = {
   fontSize?: Float;
   bold?: boolean;
 };
+
+export interface OnChangeColorEvent {
+  color: string | null;
+}
 
 export interface HtmlStyleInternal {
   h1?: Heading;
@@ -256,6 +266,7 @@ export interface NativeProps extends ViewProps {
   onMention?: DirectEventHandler<OnMentionEvent>;
   onChangeSelection?: DirectEventHandler<OnChangeSelectionEvent>;
   onRequestHtmlResult?: DirectEventHandler<OnRequestHtmlResultEvent>;
+  onColorChangeInSelection?: DirectEventHandler<OnChangeColorEvent>;
 
   // Style related props - used for generating proper setters in component's manager
   // These should not be passed as regular props
@@ -330,6 +341,10 @@ interface NativeCommands {
     viewRef: React.ElementRef<ComponentType>,
     requestId: Int32
   ) => void;
+  toggleColor: (
+    viewRef: React.ElementRef<ComponentType>,
+    color: string
+  ) => void;
 }
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
@@ -361,6 +376,7 @@ export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
     'startMention',
     'addMention',
     'requestHTML',
+    'toggleColor',
   ],
 });
 

--- a/src/EnrichedTextInputNativeComponent.ts
+++ b/src/EnrichedTextInputNativeComponent.ts
@@ -193,7 +193,7 @@ type Heading = {
 };
 
 export interface OnChangeColorEvent {
-  color: string | null;
+  color: string;
 }
 
 export interface HtmlStyleInternal {

--- a/src/EnrichedTextInputNativeComponent.ts
+++ b/src/EnrichedTextInputNativeComponent.ts
@@ -341,10 +341,8 @@ interface NativeCommands {
     viewRef: React.ElementRef<ComponentType>,
     requestId: Int32
   ) => void;
-  toggleColor: (
-    viewRef: React.ElementRef<ComponentType>,
-    color: string
-  ) => void;
+  setColor: (viewRef: React.ElementRef<ComponentType>, color: string) => void;
+  removeColor: (viewRef: React.ElementRef<ComponentType>) => void;
 }
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
@@ -376,7 +374,8 @@ export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
     'startMention',
     'addMention',
     'requestHTML',
-    'toggleColor',
+    'setColor',
+    'removeColor',
   ],
 });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,4 +6,5 @@ export type {
   OnLinkDetected,
   OnMentionDetected,
   OnChangeSelectionEvent,
+  OnChangeColorEvent,
 } from './EnrichedTextInputNativeComponent';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

In this PR, I added foreground color style support for iOS. Currently, it allows changing color in any kind of style, and it uses the font tag to identify colored parts of attributed text from HTML. To track color in already colored styles, we need to check that the current location is in this style and the color is not the same as the configured one. 

Also, I'm not sure about the onSelectionColor event, do we need to run it only when we're in the color style, or would it be better to do it always?

## Test Plan

1. Open an app
2. Try to add any colored text
3. Check the HTML output

## Screenshots / Videos

https://github.com/user-attachments/assets/eac3ae6d-0fbf-4a0a-9ddf-421527f4f568


Include any visual proof that helps reviewers understand the change — UI updates, bug reproduction or the result of the fix.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
