### PR TITLE
feat: unify initial text/html iOS emitting with Android

### DIFF
--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -75,7 +75,7 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
   _recentlyActiveMentionRange = NSMakeRange(0, 0);
   recentlyChangedRange = NSMakeRange(0, 0);
   _recentlyEmittedString = @"";
-  _recentlyEmittedHtml = @"";
+  _recentlyEmittedHtml = @"<html>\n<p></p>\n</html>";
   _emitHtml = NO;
   blockEmitting = NO;
   _emitFocusBlur = YES;
@@ -1052,6 +1052,12 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
     [h3Style handleImproperHeadings];
   }
   
+  // mentions removal management
+  MentionStyle *mentionStyleClass = (MentionStyle *)stylesDict[@([MentionStyle getStyleType])];
+  if(mentionStyleClass != nullptr) {
+    [mentionStyleClass handleExistingMentions];
+  }
+  
   // placholder management
   if(!_placeholderLabel.hidden && textView.textStorage.string.length > 0) {
     [self setPlaceholderLabelShown:NO];
@@ -1060,12 +1066,6 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
   }
   
   if(![textView.textStorage.string isEqualToString:_recentlyEmittedString]) {
-    // mentions removal management
-    MentionStyle *mentionStyleClass = (MentionStyle *)stylesDict[@([MentionStyle getStyleType])];
-    if(mentionStyleClass != nullptr) {
-      [mentionStyleClass handleExistingMentions];
-    }
-    
     // modified words handling
     NSArray *modifiedWords = [WordsUtils getAffectedWordsFromText:textView.textStorage.string modificationRange:recentlyChangedRange];
     if(modifiedWords != nullptr) {
@@ -1087,13 +1087,13 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
     // emit onChangeText event
     auto emitter = [self getEventEmitter];
     if(emitter != nullptr) {
+      // set the recently emitted string only if the emitter is defined
+      _recentlyEmittedString = stringToBeEmitted;
+      
       emitter->onChangeText({
         .value = [stringToBeEmitted toCppString]
       });
     }
-    
-    // set the recently emitted string
-    _recentlyEmittedString = stringToBeEmitted;
   }
   
   // update height on each character change


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

After the latest PRs it also came to my mind that Android and iOS emit the initial events a bit differently. If we have some `defaultValue` set, iOS wouldn't emit text (and would emit html always, even if `defaultValue` was not set), while Android properly emitted both html and text only if the prop is set.

This PR changes: 
- initial `recentlyEmittedHtml` value so that it doesn't emit with no `defaultValue`
- sets `recentlyEmittedString` only if the `onChangeText` event properly wen through (event emitter was defined). This way text emits if it's different than the initial `""`

## Test Plan

Run the example iOS app once with no `defaultValue` and the other time with `defaultValue`. Observe that in the first scenario no initial events are dispatched, while in the second they are emitted as soon as emitter is ready.


## Screenshots / Videos

--

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅ (was fine already)    |
