### PR TITLE
fix: iOS links

### DIFF
--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -711,9 +711,6 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
   if(detectedLinkData != nullptr) {
     // emit onLinkeDetected event
     [self emitOnLinkDetectedEvent:detectedLinkData.text url:detectedLinkData.url range:detectedLinkRange];
-    
-    _recentlyActiveLinkData = detectedLinkData;
-    _recentlyActiveLinkRange = detectedLinkRange;
   }
   
   if(detectedMentionParams != nullptr) {
@@ -812,6 +809,13 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
 - (void)emitOnLinkDetectedEvent:(NSString *)text url:(NSString *)url range:(NSRange)range {
   auto emitter = [self getEventEmitter];
   if(emitter != nullptr) {
+    // update recently active link info
+    LinkData *newLinkData = [[LinkData alloc] init];
+    newLinkData.text = text;
+    newLinkData.url = url;
+    _recentlyActiveLinkData = newLinkData;
+    _recentlyActiveLinkRange = range;
+  
     emitter->onLinkDetected({
       .text = [text toCppString],
       .url = [url toCppString],

--- a/ios/styles/LinkStyle.mm
+++ b/ios/styles/LinkStyle.mm
@@ -167,7 +167,6 @@ static NSString *const AutomaticLinkAttributeName = @"AutomaticLinkAttributeName
   }
   
   [self manageLinkTypingAttributes];
-  [_input anyTextMayHaveBeenModified];
 }
 
 // get exact link data at the given location if it exists
@@ -351,10 +350,9 @@ static NSString *const AutomaticLinkAttributeName = @"AutomaticLinkAttributeName
     }
     if(addStyle) {
       [self addLink:word url:regexPassedUrl range:wordRange manual:NO];
+      // emit onLinkDetected if style was added
+      [_input emitOnLinkDetectedEvent:word url:regexPassedUrl range:wordRange];
     }
-  
-    // emit onLinkDetected
-    [_input emitOnLinkDetectedEvent:word url:regexPassedUrl range:wordRange];
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Firstly, it turns out that something in the internal implementation of `attribute:atIndex:longestEffectiveRange:inRange` has been changed and if no attribute has been found, longest effective range is set to whole range we are searching in. This resulted in links wrongly returning that their range is whole input and it had implications in fonts and foreground colors randomly breaking when applying links.

Secondly, improved detecting links. The detection made after updating an automatic link didn't take recently emitted link into consideration and ran the event even if the automatic link wasn't updated - resulting in a double emit. The text when applying link was also double emitted because `LinkStyle's` `addLink` redundantly called `anyTextMayHaveBeenModified`

## Test Plan

- To check the first issue, apply a manual link via link editor while having some inline code and blockquotes in the input. See that their styling is stil intact.
- For the second one just add an automatic link and see no double emitting in console.

## Screenshots / Videos

--

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌(doesn't apply)     |
