### PR TITLE
fix: iOS nested tags

### DIFF
--- a/ios/inputParser/InputParser.mm
+++ b/ios/inputParser/InputParser.mm
@@ -184,6 +184,25 @@
         }
       }
       
+      // if a style begins but there is a style inner to it that is (and was previously) active, it also should be closed and readded
+      
+      // newly added styles
+      NSMutableSet *newStyles = [currentActiveStyles mutableCopy];
+      [newStyles minusSet: previousActiveStyles];
+      // styles that were and still are active
+      NSMutableSet *stillActiveStyles = [previousActiveStyles mutableCopy];
+      [stillActiveStyles intersectSet:currentActiveStyles];
+      
+      for(NSNumber *style in newStyles) {
+        for(NSNumber *ongoingStyle in stillActiveStyles) {
+          if([ongoingStyle integerValue] > [style integerValue]) {
+            // the prev style is inner; needs to be closed and re-added later
+            [fixedEndedStyles addObject:ongoingStyle];
+            [stylesToBeReAdded addObject:ongoingStyle];
+          }
+        }
+      }
+      
       // they are sorted in a descending order
       NSArray<NSNumber*> *sortedEndedStyles = [fixedEndedStyles sortedArrayUsingDescriptors:@[[NSSortDescriptor sortDescriptorWithKey:@"intValue" ascending:NO]]];
       
@@ -193,9 +212,8 @@
         [result appendString: [NSString stringWithFormat:@"</%@>", tagContent]];
       }
       
-      // get styles that have begun: they are sorted in a ascending manner to properly keep tags' FILO order
-      NSMutableSet<NSNumber *> *newStyles = [currentActiveStyles mutableCopy];
-      [newStyles minusSet: previousActiveStyles];
+      // all styles that have begun: new styles + the ones that need to be re-added
+      // they are sorted in a ascending manner to properly keep tags' FILO order
       [newStyles unionSet: stylesToBeReAdded];
       NSArray<NSNumber*> *sortedNewStyles = [newStyles sortedArrayUsingDescriptors:@[[NSSortDescriptor sortDescriptorWithKey:@"intValue" ascending:YES]]];
       


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Turns out nested tags logic isn't perfect on iOS yet. 
Adding a styling like this:
<img width="382" height="284" alt="image" src="https://github.com/user-attachments/assets/04b96797-43d4-42c4-8ef0-f4ba98fa5f86" />
(bold and strikethrough, then only strikethrough, then again both of them)
Results in an invalid html:
```
<html>
<p><b><s>Both</s></b><s>onlystrike<b>both</s></b></p>
</html>
```
The `s` tag should have been closed before another `b` tag and opened again after it.

This PR fixes that situation, making sure all tags that were active index ago and are still active on the index under consideration, if inner to a newly opened tag, will be closed and re-opened.

## Test Plan

Try re-creating the text described in the Summary.
See that it produces a valid html now:
```
<html>
<p><b><s>Both</s></b><s>onlystrike</s><b><s>both</s></b></p>
</html>
```

## Screenshots / Videos

--

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    doesn't apply     |
