### PR TITLE
fix: styles merging logic

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/styles/InlineStyles.kt
+++ b/android/src/main/java/com/swmansion/enriched/styles/InlineStyles.kt
@@ -2,6 +2,7 @@ package com.swmansion.enriched.styles
 
 import android.text.Editable
 import android.text.Spannable
+import android.util.Log
 import com.swmansion.enriched.EnrichedTextInputView
 import com.swmansion.enriched.spans.EnrichedSpans
 import com.swmansion.enriched.utils.getSafeSpanBoundaries
@@ -54,8 +55,7 @@ class InlineStyles(private val view: EnrichedTextInputView) {
       val spanEnd = spannable.getSpanEnd(span)
       var finalStart: Int? = null
       var finalEnd: Int? = null
-
-      spannable.removeSpan(span)
+      if (spanStart == -1 || spanEnd == -1) continue
 
       if (start == spanStart && end == spanEnd) {
         setSpanOnFinish = false


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

- Fixes: https://github.com/software-mansion/react-native-enriched/issues/279

## Test Plan

- Make one word bold.
- Make another, separate word bold.
- Create a selection starting from the middle of the first bold word to the middle of the second bold word (the selection will include bold → regular → bold segments).
- Call toggleBold.
- Notice that styles are properly applied

## Screenshots / Videos

https://github.com/user-attachments/assets/06a4a0f2-be03-467a-a982-f4413a86e1c7

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
