### PR TITLE
fix: parsing empty elements

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/utils/EnrichedParser.java
+++ b/android/src/main/java/com/swmansion/enriched/utils/EnrichedParser.java
@@ -412,7 +412,6 @@ class HtmlToSpannedConverter implements ContentHandler {
   }
 
   private void handleStartTag(String tag, Attributes attributes) {
-    isEmptyTag = false;
     if (tag.equalsIgnoreCase("br")) {
       // We don't need to handle this. TagSoup will ensure that there's a </br> for each <br>
       // so we can safely emit the linebreaks when we handle the close tag.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Fixes: https://github.com/software-mansion/react-native-enriched/issues/275
Parsing empty elements has been broken, when there was an empty inline tag inside it

## Test Plan

- Paste following html as a default value:
```html
<html><p>Asd</p><p>Asd</p><p>Asd</p><p><b>Asd</b></p><p><b>Asd</b></p><ul><li><b>asd</b></li><li><b>asd</b></li><li><b>asd</b></li><li><b></b></li></ul><br></html>
```
- Notice that text is parsed properly

## Screenshots / Videos

https://github.com/user-attachments/assets/926538e5-2034-40f0-90e4-8ea04994a39b

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
