### PR TITLE
feat: mentions with space - android

### DIFF
--- a/example/src/useChannelMention.ts
+++ b/example/src/useChannelMention.ts
@@ -13,6 +13,10 @@ const MOCKED_DATA = [
     id: '3',
     name: 'Engineering',
   },
+  {
+    id: '4',
+    name: 'Private channel',
+  },
 ];
 
 export const useChannelMention = () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR brings possibility to use mentions with one space inside it on Android platform.

## Test Plan

Provide **clear steps so another contributor can reproduce the behavior or verify the feature works**.  
For example:

- run example app
- enter `@John Doe`
- notice that entering whitespace does not close mention selector

## Screenshots / Videos

https://github.com/user-attachments/assets/49e0baa0-acc4-498f-a0bf-e2c3c0a67625

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
