### PR TITLE
feat: remake first measure logic to not use a static member

### DIFF
--- a/ios/internals/EnrichedTextInputViewShadowNode.h
+++ b/ios/internals/EnrichedTextInputViewShadowNode.h
@@ -35,8 +35,7 @@ class EnrichedTextInputViewShadowNode : public ConcreteViewShadowNode<
     
     private:
     int localForceHeightRecalculationCounter_;
-    static id mockTextInputView_;
-    void setupMockTextInputView_();
+    id setupMockTextInputView_() const;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

First render (or rather render without an accessible Component View) used a mock component view for measurements as a static member of the Shadow Node. For obvious reasons this won't work with multiple inputs on the same screen.
Original motivation for having mock as a member was to have it created as soon as possible (Shadow Node constructor) to make sure it can be measured on the first render. Turns out it can be very well created just when needed (as long as on main thread) without any first render performance losses.
This PR remakes and simplifies this approach so that we don't need a static member anymore.

## Test Plan

Run iOS example app and add a simple state to conditionally render the component. Record its first renders and notice it still properly is rendered with the proper height at once, no stutters or jumps.

## Screenshots / Videos

--

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |   ❌     |
