### PR TITLE
fix: codeblock radius on Android

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/spans/EnrichedCodeBlockSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/spans/EnrichedCodeBlockSpan.kt
@@ -2,8 +2,10 @@ package com.swmansion.enriched.spans
 
 import android.graphics.Canvas
 import android.graphics.Paint
+import android.graphics.Path
 import android.graphics.RectF
 import android.graphics.Typeface
+import android.text.Spanned
 import android.text.TextPaint
 import android.text.style.LineBackgroundSpan
 import android.text.style.MetricAffectingSpan
@@ -33,10 +35,43 @@ class EnrichedCodeBlockSpan(private val htmlStyle: HtmlStyle) : MetricAffectingS
     end: Int,
     lineNum: Int
   ) {
+    if (text !is Spanned) {
+      return
+    }
+
     val previousColor = p.color
     p.color = htmlStyle.codeBlockBackgroundColor
+
+    val radius = htmlStyle.codeBlockRadius
+
+    val spanStart = text.getSpanStart(this)
+    val spanEnd = text.getSpanEnd(this)
+    val isFirstLineOfSpan = start == spanStart
+    val isLastLineOfSpan = end == spanEnd || (spanEnd + 1 == end && text[spanEnd] == '\n')
+
+    val path = Path()
+    val radii = floatArrayOf(0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f)
+
+    if (isFirstLineOfSpan) {
+      // Top-Left and Top-Right corners
+      radii[0] = radius
+      radii[1] = radius
+      radii[2] = radius
+      radii[3] = radius
+    }
+
+    if (isLastLineOfSpan) {
+      // Bottom-Right and Bottom-Left corners
+      radii[4] = radius
+      radii[5] = radius
+      radii[6] = radius
+      radii[7] = radius
+    }
+
     val rect = RectF(left.toFloat(), top.toFloat(), right.toFloat(), bottom.toFloat())
-    canvas.drawRoundRect(rect, htmlStyle.codeBlockRadius, htmlStyle.codeBlockRadius, p)
+
+    path.addRoundRect(rect, radii, Path.Direction.CW)
+    canvas.drawPath(path, p)
     p.color = previousColor
   }
 }


### PR DESCRIPTION
# Summary
Fixes: #249 
This PR fixes logic for applying radius in codeblock. It applies radius only for first line (top corners)  and the last one (bottom corners). 

## Test Plan
Run example app and create multiline codeblock. 

## Screenshots / Videos

https://github.com/user-attachments/assets/34d61c07-c490-4642-a2ed-9b5e6245ed7d



## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
