### PR TITLE
fix: use default codgen output dirs

### DIFF
--- a/android/src/main/new_arch/CMakeLists.txt
+++ b/android/src/main/new_arch/CMakeLists.txt
@@ -5,7 +5,7 @@ set(LIB_LITERAL RNEnrichedTextInputViewSpec)
 set(LIB_TARGET_NAME react_codegen_${LIB_LITERAL})
 
 set(LIB_ANDROID_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
-set(LIB_ANDROID_GENERATED_JNI_DIR ${LIB_ANDROID_DIR}/generated/jni)
+set(LIB_ANDROID_GENERATED_JNI_DIR ${LIB_ANDROID_DIR}/build/generated/source/codegen/jni)
 set(LIB_ANDROID_GENERATED_COMPONENTS_DIR ${LIB_ANDROID_GENERATED_JNI_DIR}/react/renderer/components/${LIB_LITERAL})
 
 file(GLOB LIB_MODULE_SRCS CONFIGURE_DEPENDS *.cpp react/renderer/components/${LIB_LITERAL}/*.cpp)

--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -1,9 +1,10 @@
 #import "EnrichedTextInputView.h"
+#import "EnrichedTextInputViewShadowNode.h"
+#import "EnrichedTextInputViewComponentDescriptor.h"
 #import "RCTFabricComponentsPlugins.h"
-#import <ReactNativeEnriched/EnrichedTextInputViewComponentDescriptor.h>
-#import <ReactNativeEnriched/EventEmitters.h>
-#import <ReactNativeEnriched/Props.h>
-#import <ReactNativeEnriched/RCTComponentViewHelpers.h>
+#import <react/renderer/components/RNEnrichedTextInputViewSpec/EventEmitters.h>
+#import <react/renderer/components/RNEnrichedTextInputViewSpec/Props.h>
+#import <react/renderer/components/RNEnrichedTextInputViewSpec/RCTComponentViewHelpers.h>
 #import <react/utils/ManagedObjectWrapper.h>
 #import <folly/dynamic.h>
 #import "UIView+React.h"

--- a/ios/internals/EnrichedTextInputViewComponentDescriptor.h
+++ b/ios/internals/EnrichedTextInputViewComponentDescriptor.h
@@ -1,8 +1,8 @@
 #pragma once
+#include <EnrichedTextInputViewShadowNode.h>
 #include <react/debug/react_native_assert.h>
-#include <ReactNativeEnriched/Props.h>
+#include <react/renderer/components/RNEnrichedTextInputViewSpec/Props.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
-#include <ReactNativeEnriched/EnrichedTextInputViewShadowNode.h>
 
 namespace facebook::react {
 class EnrichedTextInputViewComponentDescriptor final : public ConcreteComponentDescriptor<EnrichedTextInputViewShadowNode> {

--- a/ios/internals/EnrichedTextInputViewShadowNode.h
+++ b/ios/internals/EnrichedTextInputViewShadowNode.h
@@ -1,7 +1,7 @@
 #pragma once
-#include <ReactNativeEnriched/EventEmitters.h>
-#include <ReactNativeEnriched/Props.h>
-#include <ReactNativeEnriched/EnrichedTextInputViewState.h>
+#include <EnrichedTextInputViewState.h>
+#include <react/renderer/components/RNEnrichedTextInputViewSpec/EventEmitters.h>
+#include <react/renderer/components/RNEnrichedTextInputViewSpec/Props.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <jsi/jsi.h>

--- a/package.json
+++ b/package.json
@@ -154,10 +154,6 @@
     "name": "RNEnrichedTextInputViewSpec",
     "type": "components",
     "jsSrcsDir": "src",
-    "outputDir": {
-      "ios": "ios/generated",
-      "android": "android/generated"
-    },
     "android": {
       "javaPackageName": "com.swmansion.enriched"
     },
@@ -165,8 +161,7 @@
       "componentProvider": {
         "EnrichedTextInputView": "EnrichedTextInputView"
       }
-    },
-    "includesGeneratedCode": true
+    }
   },
   "create-react-native-library": {
     "languages": "kotlin-objc",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Currently, it creates codegen files in platform-specific folders(Android and iOS). When you fork this library, codegen can not generate/re-generate code in these folders. So, it just skips this phase.

### Why does it work for now if codegen doesn't generate code? 

If you take a look at the published files, you may notice that codegen is already included https://www.npmjs.com/package/react-native-enriched?activeTab=code . Go to the generated folders in Android or iOS.

So, in the library, you use imports from these files; however, you don't modify them at all and it's just a cosmetic

### What problems does it solve?

1. If you work on a fork version of this library, you need to store it with already "generated" code. Since codegen can not run properly. It causes additional steps for each change in the fork, and it's really problematic to handle.
2. If you would like to apply a patch package with new props/commands or any codegen-specific logic it won't work, since codegen doesn't regenerate the new code

## Test Plan

build iOS and Android

## Screenshots / Videos

Include any visual proof that helps reviewers understand the change — UI updates, bug reproduction or the result of the fix.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
