### PR TITLE
feat(iOS): move all styles in a separate file

### DIFF
--- a/ios/EnrichedTextInputStyles.h
+++ b/ios/EnrichedTextInputStyles.h
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+#import "StyleHeaders.h"
+
+@class EnrichedTextInputView;
+
+FOUNDATION_EXPORT NSDictionary<NSNumber *, id<BaseStyleProtocol>> *
+EnrichedTextInputMakeStyles(__kindof EnrichedTextInputView *input);
+
+FOUNDATION_EXPORT NSDictionary<NSNumber *, NSArray<NSNumber *> *> *
+EnrichedTextInputConflictingStyles(void);
+
+FOUNDATION_EXPORT NSDictionary<NSNumber *, NSArray<NSNumber *> *> *
+EnrichedTextInputBlockingStyles(void);

--- a/ios/EnrichedTextInputStyles.mm
+++ b/ios/EnrichedTextInputStyles.mm
@@ -1,0 +1,77 @@
+#import "EnrichedTextInputStyles.h"
+
+NSDictionary<NSNumber *, id<BaseStyleProtocol>> *
+EnrichedTextInputMakeStyles(__kindof EnrichedTextInputView *input) {
+  return @{
+    @([BoldStyle getStyleType])         : [[BoldStyle alloc] initWithInput:input],
+    @([ItalicStyle getStyleType])       : [[ItalicStyle alloc] initWithInput:input],
+    @([UnderlineStyle getStyleType])    : [[UnderlineStyle alloc] initWithInput:input],
+    @([StrikethroughStyle getStyleType]): [[StrikethroughStyle alloc] initWithInput:input],
+    @([InlineCodeStyle getStyleType])   : [[InlineCodeStyle alloc] initWithInput:input],
+    @([LinkStyle getStyleType])         : [[LinkStyle alloc] initWithInput:input],
+    @([MentionStyle getStyleType])      : [[MentionStyle alloc] initWithInput:input],
+    @([H1Style getStyleType])           : [[H1Style alloc] initWithInput:input],
+    @([H2Style getStyleType])           : [[H2Style alloc] initWithInput:input],
+    @([H3Style getStyleType])           : [[H3Style alloc] initWithInput:input],
+    @([UnorderedListStyle getStyleType]): [[UnorderedListStyle alloc] initWithInput:input],
+    @([OrderedListStyle getStyleType])  : [[OrderedListStyle alloc] initWithInput:input],
+    @([BlockQuoteStyle getStyleType])   : [[BlockQuoteStyle alloc] initWithInput:input],
+    @([CodeBlockStyle getStyleType])    : [[CodeBlockStyle alloc] initWithInput:input],
+    @([ImageStyle getStyleType])        : [[ImageStyle alloc] initWithInput:input],
+  };
+}
+
+NSDictionary<NSNumber *, NSArray<NSNumber *> *> *EnrichedTextInputConflictingStyles(void) {
+  static NSDictionary<NSNumber *, NSArray<NSNumber *> *> *dict;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    dict = @{
+      @([BoldStyle getStyleType])         : @[],
+      @([ItalicStyle getStyleType])       : @[],
+      @([UnderlineStyle getStyleType])    : @[],
+      @([StrikethroughStyle getStyleType]): @[],
+      @([InlineCodeStyle getStyleType])   : @[@([LinkStyle getStyleType]), @([MentionStyle getStyleType])],
+      @([LinkStyle getStyleType])         : @[@([InlineCodeStyle getStyleType]), @([LinkStyle getStyleType]), @([MentionStyle getStyleType])],
+      @([MentionStyle getStyleType])      : @[@([InlineCodeStyle getStyleType]), @([LinkStyle getStyleType])],
+      @([H1Style getStyleType])           : @[@([H2Style getStyleType]), @([H3Style getStyleType]), @([UnorderedListStyle getStyleType]), @([OrderedListStyle getStyleType]), @([BlockQuoteStyle getStyleType]), @([CodeBlockStyle getStyleType])],
+      @([H2Style getStyleType])           : @[@([H1Style getStyleType]), @([H3Style getStyleType]), @([UnorderedListStyle getStyleType]), @([OrderedListStyle getStyleType]), @([BlockQuoteStyle getStyleType]), @([CodeBlockStyle getStyleType])],
+      @([H3Style getStyleType])           : @[@([H1Style getStyleType]), @([H2Style getStyleType]), @([UnorderedListStyle getStyleType]), @([OrderedListStyle getStyleType]), @([BlockQuoteStyle getStyleType]), @([CodeBlockStyle getStyleType])],
+      @([UnorderedListStyle getStyleType]): @[@([H1Style getStyleType]), @([H2Style getStyleType]), @([H3Style getStyleType]), @([OrderedListStyle getStyleType]), @([BlockQuoteStyle getStyleType]), @([CodeBlockStyle getStyleType])],
+      @([OrderedListStyle getStyleType])  : @[@([H1Style getStyleType]), @([H2Style getStyleType]), @([H3Style getStyleType]), @([UnorderedListStyle getStyleType]), @([BlockQuoteStyle getStyleType]), @([CodeBlockStyle getStyleType])],
+      @([BlockQuoteStyle getStyleType])   : @[@([H1Style getStyleType]), @([H2Style getStyleType]), @([H3Style getStyleType]), @([UnorderedListStyle getStyleType]), @([OrderedListStyle getStyleType]), @([CodeBlockStyle getStyleType])],
+      @([CodeBlockStyle getStyleType])    : @[
+        @([H1Style getStyleType]), @([H2Style getStyleType]), @([H3Style getStyleType]),
+        @([BoldStyle getStyleType]), @([ItalicStyle getStyleType]), @([UnderlineStyle getStyleType]), @([StrikethroughStyle getStyleType]),
+        @([UnorderedListStyle getStyleType]), @([OrderedListStyle getStyleType]), @([BlockQuoteStyle getStyleType]),
+        @([InlineCodeStyle getStyleType]), @([MentionStyle getStyleType]), @([LinkStyle getStyleType])
+      ],
+      @([ImageStyle getStyleType])        : @[@([LinkStyle getStyleType]), @([MentionStyle getStyleType])]
+    };
+  });
+  return dict;
+}
+
+NSDictionary<NSNumber *, NSArray<NSNumber *> *> *EnrichedTextInputBlockingStyles(void) {
+  static NSDictionary<NSNumber *, NSArray<NSNumber *> *> *dict;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    dict = @{
+      @([BoldStyle getStyleType])         : @[@([CodeBlockStyle getStyleType])],
+      @([ItalicStyle getStyleType])       : @[@([CodeBlockStyle getStyleType])],
+      @([UnderlineStyle getStyleType])    : @[@([CodeBlockStyle getStyleType])],
+      @([StrikethroughStyle getStyleType]): @[@([CodeBlockStyle getStyleType])],
+      @([InlineCodeStyle getStyleType])   : @[@([CodeBlockStyle getStyleType]), @([ImageStyle getStyleType])],
+      @([LinkStyle getStyleType])         : @[@([CodeBlockStyle getStyleType]), @([ImageStyle getStyleType])],
+      @([MentionStyle getStyleType])      : @[@([CodeBlockStyle getStyleType]), @([ImageStyle getStyleType])],
+      @([H1Style getStyleType])           : @[],
+      @([H2Style getStyleType])           : @[],
+      @([H3Style getStyleType])           : @[],
+      @([UnorderedListStyle getStyleType]): @[],
+      @([OrderedListStyle getStyleType])  : @[],
+      @([BlockQuoteStyle getStyleType])   : @[],
+      @([CodeBlockStyle getStyleType])    : @[],
+      @([ImageStyle getStyleType])        : @[@([InlineCodeStyle getStyleType])]
+    };
+  });
+  return dict;
+}

--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -15,6 +15,7 @@
 #import "LayoutManagerExtension.h"
 #import "ZeroWidthSpaceUtils.h"
 #import "ParagraphAttributesUtils.h"
+#import "EnrichedTextInputStyles.h"
 
 using namespace facebook::react;
 
@@ -80,60 +81,9 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
   
   defaultTypingAttributes = [[NSMutableDictionary<NSAttributedStringKey, id> alloc] init];
   
-  stylesDict = @{
-    @([BoldStyle getStyleType]) : [[BoldStyle alloc] initWithInput:self],
-    @([ItalicStyle getStyleType]): [[ItalicStyle alloc] initWithInput:self],
-    @([UnderlineStyle getStyleType]): [[UnderlineStyle alloc] initWithInput:self],
-    @([StrikethroughStyle getStyleType]): [[StrikethroughStyle alloc] initWithInput:self],
-    @([InlineCodeStyle getStyleType]): [[InlineCodeStyle alloc] initWithInput:self],
-    @([LinkStyle getStyleType]): [[LinkStyle alloc] initWithInput:self],
-    @([MentionStyle getStyleType]): [[MentionStyle alloc] initWithInput:self],
-    @([H1Style getStyleType]): [[H1Style alloc] initWithInput:self],
-    @([H2Style getStyleType]): [[H2Style alloc] initWithInput:self],
-    @([H3Style getStyleType]): [[H3Style alloc] initWithInput:self],
-    @([UnorderedListStyle getStyleType]): [[UnorderedListStyle alloc] initWithInput:self],
-    @([OrderedListStyle getStyleType]): [[OrderedListStyle alloc] initWithInput:self],
-    @([BlockQuoteStyle getStyleType]): [[BlockQuoteStyle alloc] initWithInput:self],
-    @([CodeBlockStyle getStyleType]): [[CodeBlockStyle alloc] initWithInput:self],
-    @([ImageStyle getStyleType]): [[ImageStyle alloc] initWithInput:self]
-  };
-  
-  conflictingStyles = @{
-    @([BoldStyle getStyleType]) : @[],
-    @([ItalicStyle getStyleType]) : @[],
-    @([UnderlineStyle getStyleType]) : @[],
-    @([StrikethroughStyle getStyleType]) : @[],
-    @([InlineCodeStyle getStyleType]) : @[@([LinkStyle getStyleType]), @([MentionStyle getStyleType])],
-    @([LinkStyle getStyleType]): @[@([InlineCodeStyle getStyleType]), @([LinkStyle getStyleType]), @([MentionStyle getStyleType])],
-    @([MentionStyle getStyleType]): @[@([InlineCodeStyle getStyleType]), @([LinkStyle getStyleType])],
-    @([H1Style getStyleType]): @[@([H2Style getStyleType]), @([H3Style getStyleType]), @([UnorderedListStyle getStyleType]), @([OrderedListStyle getStyleType]), @([BlockQuoteStyle getStyleType]), @([CodeBlockStyle getStyleType])],
-    @([H2Style getStyleType]): @[@([H1Style getStyleType]), @([H3Style getStyleType]), @([UnorderedListStyle getStyleType]), @([OrderedListStyle getStyleType]), @([BlockQuoteStyle getStyleType]), @([CodeBlockStyle getStyleType])],
-    @([H3Style getStyleType]): @[@([H1Style getStyleType]), @([H2Style getStyleType]), @([UnorderedListStyle getStyleType]), @([OrderedListStyle getStyleType]), @([BlockQuoteStyle getStyleType]), @([CodeBlockStyle getStyleType])],
-    @([UnorderedListStyle getStyleType]): @[@([H1Style getStyleType]), @([H2Style getStyleType]), @([H3Style getStyleType]), @([OrderedListStyle getStyleType]), @([BlockQuoteStyle getStyleType]), @([CodeBlockStyle getStyleType])],
-    @([OrderedListStyle getStyleType]): @[@([H1Style getStyleType]), @([H2Style getStyleType]), @([H3Style getStyleType]), @([UnorderedListStyle getStyleType]), @([BlockQuoteStyle getStyleType]), @([CodeBlockStyle getStyleType])],
-    @([BlockQuoteStyle getStyleType]): @[@([H1Style getStyleType]), @([H2Style getStyleType]), @([H3Style getStyleType]), @([UnorderedListStyle getStyleType]), @([OrderedListStyle getStyleType]), @([CodeBlockStyle getStyleType])],
-    @([CodeBlockStyle getStyleType]): @[@([H1Style getStyleType]), @([H2Style getStyleType]), @([H3Style getStyleType]),
-        @([BoldStyle getStyleType]), @([ItalicStyle getStyleType]), @([UnderlineStyle getStyleType]), @([StrikethroughStyle getStyleType]), @([UnorderedListStyle getStyleType]), @([OrderedListStyle getStyleType]), @([BlockQuoteStyle getStyleType]), @([InlineCodeStyle getStyleType]), @([MentionStyle getStyleType]), @([LinkStyle getStyleType])],
-    @([ImageStyle getStyleType]) : @[@([LinkStyle getStyleType]), @([MentionStyle getStyleType])]
-  };
-  
-  blockingStyles = @{
-    @([BoldStyle getStyleType]) : @[@([CodeBlockStyle getStyleType])],
-    @([ItalicStyle getStyleType]) : @[@([CodeBlockStyle getStyleType])],
-    @([UnderlineStyle getStyleType]) : @[@([CodeBlockStyle getStyleType])],
-    @([StrikethroughStyle getStyleType]) : @[@([CodeBlockStyle getStyleType])],
-    @([InlineCodeStyle getStyleType]) : @[@([CodeBlockStyle getStyleType]), @([ImageStyle getStyleType])],
-    @([LinkStyle getStyleType]): @[@([CodeBlockStyle getStyleType]), @([ImageStyle getStyleType])],
-    @([MentionStyle getStyleType]): @[@([CodeBlockStyle getStyleType]), @([ImageStyle getStyleType])],
-    @([H1Style getStyleType]): @[],
-    @([H2Style getStyleType]): @[],
-    @([H3Style getStyleType]): @[],
-    @([UnorderedListStyle getStyleType]): @[],
-    @([OrderedListStyle getStyleType]): @[],
-    @([BlockQuoteStyle getStyleType]): @[],
-    @([CodeBlockStyle getStyleType]): @[],
-    @([ImageStyle getStyleType]) : @[@([InlineCodeStyle getStyleType])]
-  };
+  stylesDict = EnrichedTextInputMakeStyles(self);
+  conflictingStyles = EnrichedTextInputConflictingStyles();
+  blockingStyles = EnrichedTextInputBlockingStyles();
   
   parser = [[InputParser alloc] initWithInput:self];
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

The file `EnrichedTextInputView.mm `it's huge, and it's really difficult to work with it. So now it handles everything, including styles/props/style application logic, etc. I decided to simplify it by dividing the logic into different classes with the same responsibility. So, the easiest way is to transfer the styles to a separate file. 

This PR code basically moves all the styles to a separate file to reduce the number of lines and simplify the logic in `EnrichedTextInputView.mm `

## Test Plan

Build an example app for iOS

## Screenshots / Videos

Include any visual proof that helps reviewers understand the change — UI updates, bug reproduction or the result of the fix.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
