### PR TITLE
fix: ios scrolling issues

### DIFF
--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -599,7 +599,7 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
     context: nullptr
   ];
 
-  return CGSizeMake(textView.frame.size.width, ceil(boundingBox.size.height));
+  return CGSizeMake(maxWidth, ceil(boundingBox.size.height));
 }
 
 // make sure the newest state is kept in _state property


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR should fix scrolling issues on iOS, when provided `defaultValue` is long, but it's just a single paragraph (no new line characters inside)

## Test Plan

- Set either maxHeight or fixed height for `EnrichedTextInput`
- As a default value set one line long text
- Provided text should be long enough, so input should be scrollable
- Notice that component scrolls well
- Notice that modifying defaultValue in runtime still handles scrolling behavior properly

## Screenshots / Videos

https://github.com/user-attachments/assets/fbccbc05-0f8d-49ae-a1f0-9699ff92c9f8

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌ (works fine already)     |
