### PR TITLE
fix: merging adjacent continuous paragraph styles on Android

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/spans/EnrichedSpans.kt
+++ b/android/src/main/java/com/swmansion/enriched/spans/EnrichedSpans.kt
@@ -123,4 +123,8 @@ object EnrichedSpans {
       else -> null
     }
   }
+
+  fun isTypeContinuous(type: Class<*>): Boolean {
+    return paragraphSpans.values.find { it.clazz == type }?.isContinuous == true
+  }
 }


### PR DESCRIPTION
# Summary

Merge adjacent continuous spans to maintain single set of html tags and proper rounded corners for code blocks.

## Test Plan
Run example app and:
1. Create two codeblocks/blockquotes separated with line without codeblock style -> delete this line (blocks should merge)
2. Create one codeblock/blockquotes go to next line and create the other one (blocks should merge)

## Screenshots / Videos

https://github.com/user-attachments/assets/172cec6c-88ff-49d7-b897-4e6433983ad3



## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
