### PR TITLE
feat: do not parse spannable if it's not needed - Android

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/EnrichedTextInputView.kt
+++ b/android/src/main/java/com/swmansion/enriched/EnrichedTextInputView.kt
@@ -62,6 +62,7 @@ class EnrichedTextInputView : AppCompatEditText {
   var spanWatcher: EnrichedSpanWatcher? = null
   var layoutManager: EnrichedTextInputViewLayoutManager = EnrichedTextInputViewLayoutManager(this)
 
+  var shouldEmitHtml: Boolean = true
   var experimentalSynchronousEvents: Boolean = false
 
   var fontSize: Float? = null

--- a/android/src/main/java/com/swmansion/enriched/EnrichedTextInputViewManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/EnrichedTextInputViewManager.kt
@@ -177,7 +177,7 @@ class EnrichedTextInputViewManager : SimpleViewManager<EnrichedTextInputView>(),
   }
 
   override fun setIsOnChangeHtmlSet(view: EnrichedTextInputView?, value: Boolean) {
-    // this prop isn't used on Android as of now, but the setter must be present
+    view?.shouldEmitHtml = value
   }
 
   override fun setAutoCapitalize(view: EnrichedTextInputView?, flag: String?) {

--- a/android/src/main/java/com/swmansion/enriched/watchers/EnrichedSpanWatcher.kt
+++ b/android/src/main/java/com/swmansion/enriched/watchers/EnrichedSpanWatcher.kt
@@ -52,6 +52,9 @@ class EnrichedSpanWatcher(private val view: EnrichedTextInputView) : SpanWatcher
   }
 
   fun emitEvent(s: Spannable, what: Any?) {
+    // Do not parse spannable and emit event if onChangeHtml is not provided
+    if (!view.shouldEmitHtml) return
+
     // Emit event only if we change one of ours spans
     if (what != null && what !is EnrichedSpan) return
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Android only, already implemented on iOS. This PR ensures that spannable is not parsed into HTML, when `onChangeHtml` is not provided, which slightly improvements performance.

## Test Plan

Provide **clear steps so another contributor can reproduce the behavior or verify the feature works**.  
For example:

- add a native android log inside `EnrichedSpanWatcher.emitEvent`
- ensure `onChangeHtml` prop is provided
- notice that any text/style change triggers spannable -> HTML parsing
- remove `onChangeHtml`
- notice that spannable -> HTML is not parsed, as it's not needed

## Screenshots / Videos

n/a

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
