### PR TITLE
fix: merging codeblocks when deleting first character

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/styles/ParagraphStyles.kt
+++ b/android/src/main/java/com/swmansion/enriched/styles/ParagraphStyles.kt
@@ -67,7 +67,7 @@ class ParagraphStyles(private val view: EnrichedTextInputView) {
       spannable.removeSpan(previousSpan)
     }
 
-    if (nextSpan != null) {
+    if (nextSpan != null && start != end) {
       newEnd = spannable.getSpanEnd(nextSpan)
       spannable.removeSpan(nextSpan)
     }


### PR DESCRIPTION
# Summary

This PR fixes merging codeblocks when deleting first character from `codeblock`

## Test Plan
Run example app and:
1.  write test in first line 
2. press enter
3. create codeblock with some text in it
4. navigate with cursor to the codeblock beginning
5. press backspace

Result:
The codeblock should not extend on previous line

## Screenshots / Videos
Previously:

https://github.com/user-attachments/assets/08ad083d-06e3-44e8-a446-ca6b460adf43

Right now:


https://github.com/user-attachments/assets/06b7dd0c-b3e9-4ce5-a7e2-f919e06e5d4a



## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
