### PR TITLE
fix: toggling inline styles - Android

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/styles/InlineStyles.kt
+++ b/android/src/main/java/com/swmansion/enriched/styles/InlineStyles.kt
@@ -2,7 +2,6 @@ package com.swmansion.enriched.styles
 
 import android.text.Editable
 import android.text.Spannable
-import android.util.Log
 import com.swmansion.enriched.EnrichedTextInputView
 import com.swmansion.enriched.spans.EnrichedSpans
 import com.swmansion.enriched.utils.getSafeSpanBoundaries
@@ -56,6 +55,8 @@ class InlineStyles(private val view: EnrichedTextInputView) {
       var finalStart: Int? = null
       var finalEnd: Int? = null
       if (spanStart == -1 || spanEnd == -1) continue
+
+      spannable.removeSpan(span)
 
       if (start == spanStart && end == spanEnd) {
         setSpanOnFinish = false


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

- Fixes issue introduced in https://github.com/software-mansion/react-native-enriched/pull/281

## Test Plan

Provide **clear steps so another contributor can reproduce the behavior or verify the feature works**.  
For example:

- Make one word bold.
- Make another, separate word bold.
- Create a selection starting from the middle of the first bold word to the middle of the second bold word (the selection will include bold → regular → bold segments).
- Call toggleBold.
- Notice that styles are properly applied

Also:
- set one word bold
- mark bold word
- toggle bold style and notice that style is properly removed

## Screenshots / Videos

https://github.com/user-attachments/assets/d98687c6-9b8d-4d9a-b157-9b6b07753dfe

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
