### PR TITLE
fix: emitting onEndMention event - android

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/events/MentionHandler.kt
+++ b/android/src/main/java/com/swmansion/enriched/events/MentionHandler.kt
@@ -9,8 +9,8 @@ class MentionHandler(private val view: EnrichedTextInputView) {
   private var previousIndicator: String? = null
 
   fun reset() {
+    endMention()
     previousText = null
-    previousIndicator = null
   }
 
   fun endMention() {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -262,7 +262,6 @@ export default function App() {
       id: item.id,
       type: 'user',
     });
-    closeUserMentionPopup();
   };
 
   const handleChannelMentionSelected = (item: MentionItem) => {
@@ -270,7 +269,6 @@ export default function App() {
       id: item.id,
       type: 'channel',
     });
-    closeChannelMentionPopup();
   };
 
   const handleFocusEvent = () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Fixes: https://github.com/software-mansion/react-native-enriched/issues/312
## Test Plan

- Start a `@` mention and click an option in your UI that calls `setMention`
- Notice that `onEndMention` is called after setting mention

## Screenshots / Videos

n/a

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
