### PR TITLE
fix(iOS): remove unnecessary spaces during html preparation

### DIFF
--- a/ios/inputParser/InputParser.mm
+++ b/ios/inputParser/InputParser.mm
@@ -734,7 +734,7 @@
  *
  * APPROACH:
  * This function treats the HTML as having two distinct states:
- * 1. Structure Mode (Depth == 0): We are inside container tags (like
+ * 1. Structure Mode (Depth == 0): We are inside or between container tags (like
  * <blockquote>, <ul>, <codeblock>). In this mode whitespace and newlines are
  * considered layout artifacts and are REMOVED to prevent the parser from
  * creating unwanted spaces.


### PR DESCRIPTION
# Summary
Fixes: #290 

This PR adds functionality for removing unnecessary whitespaces that breaks our html parsing.

## Test Plan

Run test case from issue: #290 

## Screenshots / Videos

https://github.com/user-attachments/assets/48547d56-a554-498e-bd90-b66f8c6015b0


https://github.com/user-attachments/assets/2c6b298b-278d-4f95-8a76-4a2117214bb9



## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
