### PR TITLE
chore: avoid double text copy in selection change - iOS

### DIFF
--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -1288,6 +1288,7 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
   if (linkStyleClass != nullptr) {
     [linkStyleClass manageLinkTypingAttributes];
   }
+  NSString *currentString = [textView.textStorage.string copy];
 
   // mention typing attribtues fix and active editing
   MentionStyle *mentionStyleClass =
@@ -1298,14 +1299,12 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
     // mention editing runs if only a selection was done (no text change)
     // otherwise we would double-emit with a second call in the
     // anyTextMayHaveBeenModified method
-    if ([_recentInputString
-            isEqualToString:[textView.textStorage.string copy]]) {
+    if ([_recentInputString isEqualToString:currentString]) {
       [mentionStyleClass manageMentionEditing];
     }
   }
 
   // typing attributes for empty lines selection reset
-  NSString *currentString = [textView.textStorage.string copy];
   if (textView.selectedRange.length == 0 &&
       [_recentInputString isEqualToString:currentString]) {
     // no string change means only a selection changed with no character changes


### PR DESCRIPTION
# Summary

Text copying is an expensive operation and may take up to 5ms in large texts. In the selection change, we did this twice. To improve performance, we can copy it only once

## Test Plan

1. Run the example app
2. Type some text
3. Change selection

## Screenshots / Videos

n/a

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
