### PR TITLE
feat: improve new lines handling performance in inline code styles

### DIFF
--- a/ios/styles/InlineCodeStyle.mm
+++ b/ios/styles/InlineCodeStyle.mm
@@ -165,7 +165,7 @@
   for (NSUInteger index = 0; index < length; index++) {
     unichar ch = CFStringGetCharacterFromInlineBuffer(&buffer, index);
     // check new lines only
-    if (ch != '\n' && ch != '\r')
+    if (![[NSCharacterSet newlineCharacterSet] characterIsMember:ch])
       continue;
 
     NSRange newlineRange = NSMakeRange(index, 1);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Imroved handlingNewLines performance in inlineCode style in iOS by using CFStringInlineBuffer 

Before, it took ~8ms for a single character with large text. 

<img width="1269" height="992" alt="Screenshot 2026-01-06 at 23 17 33" src="https://github.com/user-attachments/assets/fe5fa546-0e10-486b-b387-a755110d446d" />

Now I don't see this call method in the stacktrace

<img width="1293" height="995" alt="Screenshot 2026-01-06 at 23 26 25" src="https://github.com/user-attachments/assets/1e719045-d00d-47cb-a990-ffdcc11f4c25" />


## Test Plan

1. Set the initial HTML like:

```.ts
const generateHugeHtml = (repeat = 200) => {
  const parts: string[] = [];
  parts.push('<html>');

  // small helper to make deterministic colors
  // const colorAt = (i: number) => {
  //   const r = (37 * (i + 1)) % 256;
  //   const g = (83 * (i + 7)) % 256;
  //   const b = (199 * (i + 13)) % 256;
  //   const toHex = (n: number) => n.toString(16).padStart(2, '0');
  //   return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
  // };

  for (let i = 0; i < repeat; i++) {
    // const col = colorAt(i);
    const imgW = 200 + (i % 5) * 40;
    const imgH = 100 + (i % 3) * 30;

    parts.push(
      // Headings
      `\n<h1>Section ${i + 1}</h1>`,
      `\n<h2>Subsection ${i + 1}.1</h2>`,
      `\n<h3>Topic ${i + 1}.1.a</h3>`,

      // Paragraph with mixed inline styles
      `\n<p>This is a <b>bold</b> and <i>italic</i> paragraph with <u>underline</u>, ` +
        `<s>strike</s>, <code>inline_code_${i}</code>, ` +
        `<a href="https://example.com/${i}">a link ${i}</a>, ` +
        `<mention text="@alex_${i}" indicator="@">@alex_${i}</mention>, ` +
        `<mention text="#general" indicator="#" text="#general">#general</mention>, ` +
        `and some plain text to bulk it up.</p>`,

      // Line break
      `\n<br>`,

      // Unordered list
      `<ul>`,
      `<li>bullet A ${i}</li>`,
      `<li>bullet B ${i}</li>`,
      `<li>bullet C ${i}</li>`,
      `</ul>`,

      // Ordered list
      `\n<ol>`,
      `\n<li>step 1.${i}</li>`,
      `\n<li>step 2.${i}</li>`,
      `\n<li>step 3.${i}</li>`,
      `\n</ol>`,

      // Blockquote
      `\n<blockquote>`,
      `\n<p>"Blockquote line 1 for ${i}."</p>`,
      `\n<p>"Blockquote line 2 for ${i}."</p>`,
      `\n</blockquote>`,

      // Code block (escaped characters)
      `\n<codeblock>`,
      `\n<p>for (let k = 0; k < ${i % 7}; k++) { console.log(&quot;block_${i}&quot;); }</p>`,
      `\n</codeblock>`,

      // Image (self-closing)
      `\n<p><img src="https://picsum.photos/seed/${i}/${imgW}/${imgH}" width="${Math.min(imgW, 300)}" height="${imgH}" /></p>`
    );
  }

  parts.push('\n</html>');
  return parts.join('').replaceAll('\n', '');
};

const initialHugeHtml = generateHugeHtml();
```
2. Enable performance profiler 
3. Type a single character

## Screenshots / Videos

Include any visual proof that helps reviewers understand the change — UI updates, bug reproduction or the result of the fix.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |   ❌     |
