### PR TITLE
chore: publish workflow base setup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           name: ${{ env.PACKAGE_PATH }}
           path: ${{ env.PACKAGE_PATH }}
+          overwrite: true
           if-no-files-found: error
 
       - name: Publish package (dry-run)


### PR DESCRIPTION
# Summary

This PR introduces basic setup for publish workflow. `npm publish` is still commented out, once we know that generated tarball is valid one, I will bring it back. In order to perform tests, workflow has to be merged into main branch (as it's triggered manually by `workflow_dispatch`)

## Test Plan

n/a

## Screenshots / Videos

n/a

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
