### PR TITLE
fix: padding applied as margin

### DIFF
--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -1404,7 +1404,6 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
 
   // update active styles as well
   [self tryUpdatingActiveStyles];
-  [self ensureCursorIsVisible];
 }
 
 - (void)handleWordModificationBasedChanges:(NSString *)word
@@ -1529,45 +1528,6 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
   [self tryUpdatingHeight];
   // update active styles as well
   [self tryUpdatingActiveStyles];
-  [self ensureCursorIsVisible];
-}
-
-// Debounced scroll to cursor - coalesces multiple requests into one per runloop
-// tick
-- (void)ensureCursorIsVisible {
-  [NSObject
-      cancelPreviousPerformRequestsWithTarget:self
-                                     selector:@selector(_performScrollToCursor)
-                                       object:nil];
-
-  [self performSelector:@selector(_performScrollToCursor)
-             withObject:nil
-             afterDelay:0];
-}
-
-- (void)_performScrollToCursor {
-  if (!textView)
-    return;
-
-  if (self->textView.selectedRange.location == NSNotFound)
-    return;
-
-  UITextPosition *cursorPos = [self->textView
-      positionFromPosition:self->textView.beginningOfDocument
-                    offset:self->textView.selectedRange.location];
-  if (!cursorPos)
-    return;
-
-  CGRect caretRect = [self->textView caretRectForPosition:cursorPos];
-
-  // We don't just want to see the cursor, we want to see the cursor plus the
-  // padding.
-  UIEdgeInsets insets = self->textView.textContainerInset;
-
-  caretRect.origin.y -= insets.top;
-  caretRect.size.height += (insets.top + insets.bottom);
-
-  [self->textView scrollRectToVisible:caretRect animated:NO];
 }
 
 - (void)didMoveToWindow {

--- a/ios/utils/LayoutManagerExtension.mm
+++ b/ios/utils/LayoutManagerExtension.mm
@@ -300,9 +300,9 @@ static void const *kInputKey = &kInputKey;
                                            [marker sizeWithAttributes:
                                                        markerAttributes]
                                                .width;
-                                       CGFloat markerX = usedRect.origin.x -
-                                                         gapWidth -
-                                                         markerWidth / 2;
+                                       CGFloat markerX =
+                                           origin.x + usedRect.origin.x -
+                                           gapWidth - markerWidth / 2;
 
                                        [marker drawAtPoint:CGPointMake(
                                                                markerX,
@@ -317,11 +317,11 @@ static void const *kInputKey = &kInputKey;
                                        CGFloat bulletSize =
                                            [typedInput->config
                                                    unorderedListBulletSize];
-                                       CGFloat bulletX = usedRect.origin.x -
-                                                         gapWidth -
-                                                         bulletSize / 2;
+                                       CGFloat bulletX =
+                                           origin.x + usedRect.origin.x -
+                                           gapWidth - bulletSize / 2;
                                        CGFloat centerY =
-                                           CGRectGetMidY(usedRect);
+                                           CGRectGetMidY(usedRect) + origin.y;
 
                                        CGContextRef context =
                                            UIGraphicsGetCurrentContext();


### PR DESCRIPTION
# Summary
Fixes: #332 

1. Implemented `updateLayoutMetrics` to correctly apply `padding` for `_placeholderLabel` constraints.
2. Switched from `boundingRectWithSize` to `[textView sizeThatFits:]` to ensure measurement matches actual rendering logic exactly.
3. Removed `_performRelayout` that caused scroll flickering.
4. Added debounced `ensureCursorIsVisible` to fix cursor visibility when styles (like H1) change the text height dynamically.
5. Fix position of lists markers

## Test Plan
1. Run example code from #332 and check if the padding is not applied as margin.
2. Run example app and play with different styles - check If height of the view is correct

## Screenshots / Videos
Before:

https://github.com/user-attachments/assets/d94bff71-aa6f-4aa3-858b-af991a618cb0


After:

https://github.com/user-attachments/assets/717993c3-98ea-406c-85eb-0dbf330375f9



## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
