### PR TITLE
fix: android span watcher

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/EnrichedTextInputView.kt
+++ b/android/src/main/java/com/swmansion/enriched/EnrichedTextInputView.kt
@@ -41,6 +41,7 @@ import com.swmansion.enriched.styles.InlineStyles
 import com.swmansion.enriched.styles.ListStyles
 import com.swmansion.enriched.styles.ParagraphStyles
 import com.swmansion.enriched.styles.ParametrizedStyles
+import com.swmansion.enriched.utils.EnrichedEditableFactory
 import com.swmansion.enriched.utils.EnrichedParser
 import com.swmansion.enriched.utils.EnrichedSelection
 import com.swmansion.enriched.utils.EnrichedSpanState
@@ -124,7 +125,11 @@ class EnrichedTextInputView : AppCompatEditText {
     setPadding(0, 0, 0, 0)
     setBackgroundColor(Color.TRANSPARENT)
 
-    addSpanWatcher(EnrichedSpanWatcher(this))
+    // Ensure that every time new editable is created, it has EnrichedSpanWatcher attached
+    val spanWatcher = EnrichedSpanWatcher(this)
+    this.spanWatcher = spanWatcher
+    setEditableFactory(EnrichedEditableFactory(spanWatcher))
+
     addTextChangedListener(EnrichedTextWatcher(this))
   }
 
@@ -275,8 +280,6 @@ class EnrichedTextInputView : AppCompatEditText {
       setText(newText)
 
       observeAsyncImages()
-      // Assign SpanWatcher one more time as our previous spannable has been replaced
-      addSpanWatcher(EnrichedSpanWatcher(this))
 
       // Scroll to the last line of text
       setSelection(text?.length ?: 0)
@@ -588,12 +591,6 @@ class EnrichedTextInputView : AppCompatEditText {
     }
 
     return true
-  }
-
-  private fun addSpanWatcher(watcher: EnrichedSpanWatcher) {
-    val spannable = text as Spannable
-    spannable.setSpan(watcher, 0, spannable.length, Spannable.SPAN_INCLUSIVE_INCLUSIVE)
-    spanWatcher = watcher
   }
 
   fun verifyAndToggleStyle(name: String) {

--- a/android/src/main/java/com/swmansion/enriched/utils/EnrichedEditableFactory.kt
+++ b/android/src/main/java/com/swmansion/enriched/utils/EnrichedEditableFactory.kt
@@ -1,0 +1,17 @@
+package com.swmansion.enriched.utils
+
+import android.text.Editable
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import com.swmansion.enriched.watchers.EnrichedSpanWatcher
+
+class EnrichedEditableFactory(
+  private val watcher: EnrichedSpanWatcher,
+) : Editable.Factory() {
+  override fun newEditable(source: CharSequence): Editable {
+    val s = source as? SpannableStringBuilder ?: SpannableStringBuilder(source)
+    s.removeSpan(watcher)
+    s.setSpan(watcher, 0, s.length, Spannable.SPAN_INCLUSIVE_INCLUSIVE)
+    return s
+  }
+}


### PR DESCRIPTION
# Summary

Issue has been originally introduced in https://github.com/software-mansion/react-native-enriched/pull/343, but in general it never worked properly. Span watcher has to be attached for the whole view lifecycle, it used for handling some styling related logic. Previously we were applying it manually, but when editable instance changed it wasn't re-created. With current approach we use editable factory to ensure it's attached once new editable instance is created.

## Test Plan

- created ordered list with at least two elements
- remove first element
- notice that second element index changed (while it won't change on current main branch)

## Screenshots / Videos

https://github.com/user-attachments/assets/942e8a71-a538-4e54-8269-bb446bf3b96e


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
