### PR TITLE
fix: reapplying spans

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/styles/ListStyles.kt
+++ b/android/src/main/java/com/swmansion/enriched/styles/ListStyles.kt
@@ -10,6 +10,7 @@ import com.swmansion.enriched.spans.EnrichedSpans
 import com.swmansion.enriched.spans.EnrichedUnorderedListSpan
 import com.swmansion.enriched.utils.getParagraphBounds
 import com.swmansion.enriched.utils.getSafeSpanBoundaries
+import com.swmansion.enriched.utils.removeZWS
 
 class ListStyles(
   private val view: EnrichedTextInputView,
@@ -85,7 +86,7 @@ class ListStyles(
       ssb.removeSpan(span)
     }
 
-    ssb.replace(start, end, ssb.substring(start, end).replace("\u200B", ""))
+    ssb.removeZWS(start, end)
     return true
   }
 

--- a/android/src/main/java/com/swmansion/enriched/styles/ParagraphStyles.kt
+++ b/android/src/main/java/com/swmansion/enriched/styles/ParagraphStyles.kt
@@ -9,6 +9,7 @@ import com.swmansion.enriched.spans.EnrichedSpans
 import com.swmansion.enriched.spans.interfaces.EnrichedSpan
 import com.swmansion.enriched.utils.getParagraphBounds
 import com.swmansion.enriched.utils.getSafeSpanBoundaries
+import com.swmansion.enriched.utils.removeZWS
 
 class ParagraphStyles(
   private val view: EnrichedTextInputView,
@@ -126,7 +127,8 @@ class ParagraphStyles(
       ssb.removeSpan(span)
     }
 
-    ssb.replace(finalStart, finalEnd, ssb.substring(finalStart, finalEnd).replace("\u200B", ""))
+    ssb.removeZWS(finalStart, finalEnd)
+
     return true
   }
 

--- a/android/src/main/java/com/swmansion/enriched/styles/ParametrizedStyles.kt
+++ b/android/src/main/java/com/swmansion/enriched/styles/ParametrizedStyles.kt
@@ -10,6 +10,7 @@ import com.swmansion.enriched.spans.EnrichedLinkSpan
 import com.swmansion.enriched.spans.EnrichedMentionSpan
 import com.swmansion.enriched.spans.EnrichedSpans
 import com.swmansion.enriched.utils.getSafeSpanBoundaries
+import com.swmansion.enriched.utils.removeZWS
 
 class ParametrizedStyles(
   private val view: EnrichedTextInputView,
@@ -29,7 +30,7 @@ class ParametrizedStyles(
     val spans = ssb.getSpans(start, end, clazz)
     if (spans.isEmpty()) return false
 
-    ssb.replace(start, end, ssb.substring(start, end).replace("\u200B", ""))
+    ssb.removeZWS(start, end)
 
     for (span in spans) {
       ssb.removeSpan(span)

--- a/android/src/main/java/com/swmansion/enriched/utils/Utils.kt
+++ b/android/src/main/java/com/swmansion/enriched/utils/Utils.kt
@@ -99,3 +99,15 @@ fun Spannable.mergeSpannables(
 
   return builder
 }
+
+// Removes zero-width spaces from the given range in the SpannableStringBuilder without affecting spans
+fun SpannableStringBuilder.removeZWS(
+  start: Int,
+  end: Int,
+) {
+  for (i in (end - 1) downTo start) {
+    if (this[i] == '\u200B') {
+      delete(i, i + 1)
+    }
+  }
+}


### PR DESCRIPTION
# Summary

Fixes issue with reapplying spans after removing paragraph and list styles.
Why does it fix issue? Calling `replace` on SpannableStringBuilder replaces text and removes attached spans at the same time. With new approach we use `delete` which modifies text only.

## Test Plan

Repro:

1. Enter text: "**bold** and not bold"
2. Enable blockquote
3. Disable blockquote
4. Notice that bold style is preserved (it's not on main branch)

## Screenshots / Videos

https://github.com/user-attachments/assets/1c9cecaa-f7ca-47b7-aa88-b5c7e9b327c8

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
