### PR TITLE
chore: expose deprecated state event type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ export type {
   OnChangeTextEvent,
   OnChangeHtmlEvent,
   OnChangeStateEvent,
+  OnChangeStateDeprecatedEvent,
   OnLinkDetected,
   OnMentionDetected,
   OnChangeSelectionEvent,


### PR DESCRIPTION
# Summary

Expose `OnChangeStateDeprecatedEvent` for easier migration

