### PR TITLE
fix: focus events types

### DIFF
--- a/src/EnrichedTextInput.tsx
+++ b/src/EnrichedTextInput.tsx
@@ -30,12 +30,16 @@ import type {
   MeasureOnSuccessCallback,
   NativeMethods,
   NativeSyntheticEvent,
+  TargetedEvent,
   TextStyle,
   ViewProps,
   ViewStyle,
 } from 'react-native';
 import { normalizeHtmlStyle } from './utils/normalizeHtmlStyle';
 import { toNativeRegexConfig } from './utils/regexParser';
+
+export type FocusEvent = NativeSyntheticEvent<TargetedEvent>;
+export type BlurEvent = NativeSyntheticEvent<TargetedEvent>;
 
 export interface EnrichedTextInputInstance extends NativeMethods {
   // General commands
@@ -144,8 +148,8 @@ export interface EnrichedTextInputProps extends Omit<ViewProps, 'children'> {
   style?: ViewStyle | TextStyle;
   scrollEnabled?: boolean;
   linkRegex?: RegExp | null;
-  onFocus?: () => void;
-  onBlur?: () => void;
+  onFocus?: (e: FocusEvent) => void;
+  onBlur?: (e: BlurEvent) => void;
   onChangeText?: (e: NativeSyntheticEvent<OnChangeTextEvent>) => void;
   onChangeHtml?: (e: NativeSyntheticEvent<OnChangeHtmlEvent>) => void;
   onChangeState?: (e: NativeSyntheticEvent<OnChangeStateEvent>) => void;

--- a/src/spec/EnrichedTextInputNativeComponent.ts
+++ b/src/spec/EnrichedTextInputNativeComponent.ts
@@ -191,6 +191,10 @@ export interface OnKeyPressEvent {
   key: string;
 }
 
+interface TargetedEvent {
+  target: Int32;
+}
+
 type Heading = {
   fontSize?: Float;
   bold?: boolean;
@@ -261,8 +265,8 @@ export interface NativeProps extends ViewProps {
   linkRegex?: LinkNativeRegex;
 
   // event callbacks
-  onInputFocus?: DirectEventHandler<null>;
-  onInputBlur?: DirectEventHandler<null>;
+  onInputFocus?: DirectEventHandler<TargetedEvent>;
+  onInputBlur?: DirectEventHandler<TargetedEvent>;
   onChangeText?: DirectEventHandler<OnChangeTextEvent>;
   onChangeHtml?: DirectEventHandler<OnChangeHtmlEvent>;
   onChangeState?: DirectEventHandler<OnChangeStateEvent>;


### PR DESCRIPTION
# Summary

As per [discussion](https://github.com/software-mansion/react-native-enriched/discussions/387) this fixes incorrect types for `onBlur` and `onFocus` 

## Test Plan

Ensure types for `onFocus` and `onBlur` are defined correctly.

## Screenshots / Videos

n/a

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
