### PR TITLE
chore: generic enriched style

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/common/EnrichedStyle.kt
+++ b/android/src/main/java/com/swmansion/enriched/common/EnrichedStyle.kt
@@ -1,0 +1,57 @@
+package com.swmansion.enriched.common
+
+interface EnrichedStyle {
+  // Headers
+  val h1FontSize: Int
+  val h1Bold: Boolean
+  val h2FontSize: Int
+  val h2Bold: Boolean
+  val h3FontSize: Int
+  val h3Bold: Boolean
+  val h4FontSize: Int
+  val h4Bold: Boolean
+  val h5FontSize: Int
+  val h5Bold: Boolean
+  val h6FontSize: Int
+  val h6Bold: Boolean
+
+  // Blockquote
+  val blockquoteColor: Int?
+  val blockquoteBorderColor: Int
+  val blockquoteStripeWidth: Int
+  val blockquoteGapWidth: Int
+
+  // Ordered Lists
+  val olGapWidth: Int
+  val olMarginLeft: Int
+  val olMarkerFontWeight: Int?
+  val olMarkerColor: Int?
+
+  // Unordered Lists
+  val ulGapWidth: Int
+  val ulMarginLeft: Int
+  val ulBulletSize: Int
+  val ulBulletColor: Int
+
+  // Checkbox list
+  val ulCheckboxBoxSize: Int
+  val ulCheckboxGapWidth: Int
+  val ulCheckboxMarginLeft: Int
+  val ulCheckboxBoxColor: Int
+
+  // Links
+  val aColor: Int
+  val aUnderline: Boolean
+
+  // Code Blocks
+  val codeBlockColor: Int
+  val codeBlockBackgroundColor: Int
+  val codeBlockRadius: Float
+
+  // Inline Code
+  val inlineCodeColor: Int
+  val inlineCodeBackgroundColor: Int
+
+  // Mentions
+  val mentionsStyle: Map<String, MentionStyle>
+}

--- a/android/src/main/java/com/swmansion/enriched/common/MentionStyle.kt
+++ b/android/src/main/java/com/swmansion/enriched/common/MentionStyle.kt
@@ -1,0 +1,7 @@
+package com.swmansion.enriched.common
+
+data class MentionStyle(
+  val color: Int,
+  val backgroundColor: Int,
+  val underline: Boolean,
+)

--- a/android/src/main/java/com/swmansion/enriched/textinput/styles/HtmlStyle.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/styles/HtmlStyle.kt
@@ -6,68 +6,70 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.views.text.ReactTypefaceUtils.parseFontWeight
+import com.swmansion.enriched.common.EnrichedStyle
+import com.swmansion.enriched.common.MentionStyle
 import com.swmansion.enriched.textinput.EnrichedTextInputView
 import kotlin.Float
 import kotlin.Int
 import kotlin.String
 import kotlin.math.ceil
 
-class HtmlStyle {
+class HtmlStyle : EnrichedStyle {
   private var style: ReadableMap? = null
   private var view: EnrichedTextInputView? = null
 
   // Default values are ignored as they are specified on the JS side.
   // They are specified only because they are required by the constructor.
   // JS passes them as a prop - so they are initialized after the constructor is called.
-  var h1FontSize: Int = 72
-  var h1Bold: Boolean = false
+  override var h1FontSize: Int = 72
+  override var h1Bold: Boolean = false
 
-  var h2FontSize: Int = 64
-  var h2Bold: Boolean = false
+  override var h2FontSize: Int = 64
+  override var h2Bold: Boolean = false
 
-  var h3FontSize: Int = 56
-  var h3Bold: Boolean = false
+  override var h3FontSize: Int = 56
+  override var h3Bold: Boolean = false
 
-  var h4FontSize: Int = 48
-  var h4Bold: Boolean = false
+  override var h4FontSize: Int = 48
+  override var h4Bold: Boolean = false
 
-  var h5FontSize: Int = 40
-  var h5Bold: Boolean = false
+  override var h5FontSize: Int = 40
+  override var h5Bold: Boolean = false
 
-  var h6FontSize: Int = 32
-  var h6Bold: Boolean = false
+  override var h6FontSize: Int = 32
+  override var h6Bold: Boolean = false
 
-  var blockquoteColor: Int? = null
-  var blockquoteBorderColor: Int = Color.BLACK
-  var blockquoteStripeWidth: Int = 2
-  var blockquoteGapWidth: Int = 16
+  override var blockquoteColor: Int? = null
+  override var blockquoteBorderColor: Int = Color.BLACK
+  override var blockquoteStripeWidth: Int = 2
+  override var blockquoteGapWidth: Int = 16
 
-  var olGapWidth: Int = 16
-  var olMarginLeft: Int = 24
-  var olMarkerFontWeight: Int? = null
-  var olMarkerColor: Int? = null
+  override var olGapWidth: Int = 16
+  override var olMarginLeft: Int = 24
+  override var olMarkerFontWeight: Int? = null
+  override var olMarkerColor: Int? = null
 
-  var ulGapWidth: Int = 16
-  var ulMarginLeft: Int = 24
-  var ulBulletSize: Int = 8
-  var ulBulletColor: Int = Color.BLACK
+  override var ulGapWidth: Int = 16
+  override var ulMarginLeft: Int = 24
+  override var ulBulletSize: Int = 8
+  override var ulBulletColor: Int = Color.BLACK
 
-  var ulCheckboxBoxSize: Int = 50
-  var ulCheckboxGapWidth: Int = 16
-  var ulCheckboxMarginLeft: Int = 24
-  var ulCheckboxBoxColor: Int = Color.BLACK
+  override var ulCheckboxBoxSize: Int = 50
+  override var ulCheckboxGapWidth: Int = 16
+  override var ulCheckboxMarginLeft: Int = 24
+  override var ulCheckboxBoxColor: Int = Color.BLACK
 
-  var aColor: Int = Color.BLACK
-  var aUnderline: Boolean = true
+  override var aColor: Int = Color.BLACK
+  override var aUnderline: Boolean = true
 
-  var codeBlockColor: Int = Color.BLACK
-  var codeBlockBackgroundColor: Int = Color.BLACK
-  var codeBlockRadius: Float = 4f
+  override var codeBlockColor: Int = Color.BLACK
+  override var codeBlockBackgroundColor: Int = Color.BLACK
+  override var codeBlockRadius: Float = 4f
 
-  var inlineCodeColor: Int = Color.BLACK
-  var inlineCodeBackgroundColor: Int = Color.BLACK
+  override var inlineCodeColor: Int = Color.BLACK
+  override var inlineCodeBackgroundColor: Int = Color.BLACK
 
-  var mentionsStyle: MutableMap<String, MentionStyle> = mutableMapOf()
+  override var mentionsStyle: MutableMap<String, MentionStyle> = mutableMapOf()
 
   constructor(view: EnrichedTextInputView?, style: ReadableMap?) {
     this.view = view
@@ -366,13 +368,5 @@ class HtmlStyle {
     result = 31 * result + mentionsStyle.hashCode()
 
     return result
-  }
-
-  companion object {
-    data class MentionStyle(
-      val color: Int,
-      val backgroundColor: Int,
-      val underline: Boolean,
-    )
   }
 }


### PR DESCRIPTION
# Summary

Creates `EnrichedStyle` interface which is later used for defining `HtmlStyle`. That way we can later use base `EnrichedStyle` properties on the common level (meaning they can be reused between different components)

## Test Plan

Ensure lib builds fine

## Screenshots / Videos

n/a

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
