### PR TITLE
fix(Android): newline insertion in lists

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/textinput/styles/ListStyles.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/styles/ListStyles.kt
@@ -195,6 +195,19 @@ class ListStyles(
     }
 
     if (!isBackspace && isNewLine && isPreviousParagraphList(s, start, config.clazz)) {
+      // Check if the span from the previous line "leaked" into this one
+      if (spans.isNotEmpty()) {
+        val existingSpan = spans[0]
+        val spanStart = s.getSpanStart(existingSpan)
+
+        // If the span started before the current paragraph (belongs to the previous item)
+        // update it to end at the newline (start - 1)
+        if (spanStart < start) {
+          val spanFlags = s.getSpanFlags(existingSpan)
+          s.setSpan(existingSpan, spanStart, start - 1, spanFlags)
+        }
+      }
+
       s.insert(cursorPosition, EnrichedConstants.ZWS_STRING)
       setSpan(s, name, start, end + 1)
       // Inform that new span has been added


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR fixes adding newline in lists.

## Test Plan

1. Run example app
2. Create list (ol, ul, checkbox list):
- xxx
3. press enter after first x
4. The list should look like this:
- x
- xx

## Screenshots / Videos
Before:

https://github.com/user-attachments/assets/0ba659ae-911f-4c77-9195-22ba271b953f


After:

https://github.com/user-attachments/assets/8fd8d6de-b1fc-4597-9b07-71f1200ea879


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
