### PR TITLE
fix(ios): mention parsing

### DIFF
--- a/ios/inputParser/InputParser.mm
+++ b/ios/inputParser/InputParser.mm
@@ -1315,7 +1315,7 @@
       [styleArr addObject:@([MentionStyle getStyleType])];
       // extract html expression into dict using some regex
       NSMutableDictionary *paramsDict = [[NSMutableDictionary alloc] init];
-      NSString *pattern = @"(\\w+)=\"([^\"]*)\"";
+      NSString *pattern = @"(\\w+)=(['\"])(.*?)\\2";
       NSRegularExpression *regex =
           [NSRegularExpression regularExpressionWithPattern:pattern
                                                     options:0
@@ -1327,11 +1327,11 @@
                            usingBlock:^(NSTextCheckingResult *_Nullable result,
                                         NSMatchingFlags flags,
                                         BOOL *_Nonnull stop) {
-                             if (result.numberOfRanges == 3) {
+                             if (result.numberOfRanges == 4) {
                                NSString *key = [params
                                    substringWithRange:[result rangeAtIndex:1]];
                                NSString *value = [params
-                                   substringWithRange:[result rangeAtIndex:2]];
+                                   substringWithRange:[result rangeAtIndex:3]];
                                paramsDict[key] = value;
                              }
                            }];


### PR DESCRIPTION

# Summary

Fixes: #404 

This PR make available providing mention attributes with single quotes like:
`<mention text='@John Doe' indicator='@' id='1' type='user'>@John Doe</mention>`

not only double quotes:
`<mention text="@John Doe" indicator="@" id="1" type="user">@John Doe</mention>`

## Test Plan
Try reproduction steps from the issue: #404 and check if mention is properly styled.

## Screenshots / Videos

n/a

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
