### PR TITLE
fix: remove applying typing attr when toggling checkbox

### DIFF
--- a/ios/styles/CheckboxListStyle.mm
+++ b/ios/styles/CheckboxListStyle.mm
@@ -167,7 +167,7 @@
 
   [self addAttributesWithCheckedValue:!isCurrentlyChecked
                               inRange:paragraphRange
-                       withTypingAttr:YES];
+                       withTypingAttr:NO];
 }
 
 - (void)addAttributesWithCheckedValue:(BOOL)checked


### PR DESCRIPTION
# Summary

This PR fixes applying wrongly checkbox list typing attributes when toggling checkbox.

## Test Plan

1. Run example app
2. Create checkbox list
3. Go with the cursor to some line without checkbox style
4. Toggle some checkbox
5. Checkbox should not be created in the cursor position

## Screenshots / Videos
Before:

https://github.com/user-attachments/assets/3a930fed-9d04-4c7a-bd4e-f721c34d758e


After:

https://github.com/user-attachments/assets/d440403a-d266-47e2-8b28-a3cdbe38dd86


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
