### PR TITLE
fix: revert "fix(iOS): proper layout calculation #339"

### DIFF
--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -2064,7 +2064,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: c12d2108050e27952983d565a232f6f7b1ad5e69
-  hermes-engine: 57506c1404e8b80c5386de18743e0d02c8d4f681
+  hermes-engine: c50a496dd5a3974cde1b7d14a944bee1ee64ca0c
   RCTDeprecation: 3280799c14232a56e5a44f92981a8ee33bc69fd9
   RCTRequired: 9854a51b0f65ccf43ea0b744df4d70fce339db32
   RCTSwiftUI: 96986e49a4fdc2c2103929dee2641e1b57edf33d
@@ -2073,7 +2073,7 @@ SPEC CHECKSUMS:
   React: 7ef36630d07638043a134a7dd2ec17e0be10fc3c
   React-callinvoker: af4e8fe1d60ab63dd8d74c2a68988064c2848954
   React-Core: c0fb1df65eb0ed7a8633841831f05f93c3eb3aff
-  React-Core-prebuilt: cd92350bf2041dde22a9bc0b8984d9c70d179ca1
+  React-Core-prebuilt: 25c9d7a48b3bd78017d44e80de5fbb3eb139328d
   React-CoreModules: 7dfe7962360355f1547c85ab52e1fc4b57f17127
   React-cxxreact: 9e9c7f1710bc58abebf924813b5e825b99adb8e5
   React-debug: 38389b86e3570558ec73dd4cbc0cd2f2eec47a51
@@ -2135,7 +2135,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 625d2f6d9d5ef01acc9dfe2b5385504bbffd2ad0
   ReactCodegen: 27937747ddc743fcb66a8dc19e8edf60188d94cc
   ReactCommon: cc0e38600f82487c5fe5d29150abb6fa9d981986
-  ReactNativeDependencies: cebf665879bab2908201494cc5a9760dbdf0a637
+  ReactNativeDependencies: 8febfeb298c1be3a3699aac801aec086f0580694
   ReactNativeEnriched: 790e857a207566a6dc34e7b45480b88bddf79bed
   Yoga: 772166513f9cd2d61a6251d0dacbbfaa5b537479
 

--- a/ios/EnrichedTextInputView.h
+++ b/ios/EnrichedTextInputView.h
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @public
   BOOL blockEmitting;
 }
+- (CGSize)measureSize:(CGFloat)maxWidth;
 - (void)emitOnLinkDetectedEvent:(NSString *)text
                             url:(NSString *)url
                           range:(NSRange)range;
@@ -40,8 +41,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)handleStyleBlocksAndConflicts:(StyleType)type range:(NSRange)range;
 - (NSArray<NSNumber *> *)getPresentStyleTypesFrom:(NSArray<NSNumber *> *)types
                                             range:(NSRange)range;
-- (CGSize)measureInitialSizeWithMaxWidth:(CGFloat)maxWidth;
-- (void)commitSize:(CGSize)size;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -76,7 +76,8 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
     _props = defaultProps;
     [self setDefaults];
     [self setupTextView];
-    [self addSubview:textView];
+    [self setupPlaceholderLabel];
+    self.contentView = textView;
   }
   return self;
 }
@@ -264,12 +265,29 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
   textView.delegate = self;
   textView.input = self;
   textView.layoutManager.input = self;
-  textView.autoresizingMask =
-      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   textView.adjustsFontForContentSizeCategory = YES;
   [textView addGestureRecognizer:[[TextBlockTapGestureRecognizer alloc]
                                      initWithInput:self
                                             action:@selector(onTextBlockTap:)]];
+}
+
+- (void)setupPlaceholderLabel {
+  _placeholderLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+  _placeholderLabel.translatesAutoresizingMaskIntoConstraints = NO;
+  [textView addSubview:_placeholderLabel];
+  [NSLayoutConstraint activateConstraints:@[
+    [_placeholderLabel.leadingAnchor
+        constraintEqualToAnchor:textView.leadingAnchor],
+    [_placeholderLabel.widthAnchor
+        constraintEqualToAnchor:textView.widthAnchor],
+    [_placeholderLabel.topAnchor constraintEqualToAnchor:textView.topAnchor],
+    [_placeholderLabel.bottomAnchor
+        constraintEqualToAnchor:textView.bottomAnchor]
+  ]];
+  _placeholderLabel.lineBreakMode = NSLineBreakByTruncatingTail;
+  _placeholderLabel.text = @"";
+  _placeholderLabel.hidden = YES;
+  _placeholderLabel.adjustsFontForContentSizeCategory = YES;
 }
 
 // MARK: - Props
@@ -717,6 +735,9 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
         [[NSParagraphStyle alloc] init];
     textView.typingAttributes = defaultTypingAttributes;
     textView.selectedRange = prevSelectedRange;
+
+    // update the placeholder as well
+    [self refreshPlaceholderLabelStyles];
   }
 
   // editable
@@ -744,14 +765,24 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
 
   // placeholderTextColor
   if (newViewProps.placeholderTextColor != oldViewProps.placeholderTextColor) {
-    textView.placeholderColor =
-        RCTUIColorFromSharedColor(newViewProps.placeholderTextColor);
+    // some real color
+    if (isColorMeaningful(newViewProps.placeholderTextColor)) {
+      _placeholderColor =
+          RCTUIColorFromSharedColor(newViewProps.placeholderTextColor);
+    } else {
+      _placeholderColor = nullptr;
+    }
+    [self refreshPlaceholderLabelStyles];
   }
 
   // placeholder
   if (newViewProps.placeholder != oldViewProps.placeholder) {
-    [textView
-        setPlaceholderText:[NSString fromCppString:newViewProps.placeholder]];
+    _placeholderLabel.text = [NSString fromCppString:newViewProps.placeholder];
+    [self refreshPlaceholderLabelStyles];
+    // additionally show placeholder on first mount if it should be there
+    if (isFirstMount && textView.text.length == 0) {
+      [self setPlaceholderLabelShown:YES];
+    }
   }
 
   // mention indicators
@@ -827,17 +858,75 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
   if (isFirstMount && newViewProps.autoFocus) {
     [textView reactFocus];
   }
-  [textView updatePlaceholderVisibility];
 }
 
-- (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics
-           oldLayoutMetrics:(const LayoutMetrics &)oldLayoutMetrics {
-  [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
+- (void)setPlaceholderLabelShown:(BOOL)shown {
+  if (shown) {
+    [self refreshPlaceholderLabelStyles];
+    _placeholderLabel.hidden = NO;
+  } else {
+    _placeholderLabel.hidden = YES;
+  }
+}
 
-  textView.frame = UIEdgeInsetsInsetRect(
-      self.bounds, RCTUIEdgeInsetsFromEdgeInsets(layoutMetrics.borderWidth));
-  textView.textContainerInset = RCTUIEdgeInsetsFromEdgeInsets(
-      layoutMetrics.contentInsets - layoutMetrics.borderWidth);
+- (void)refreshPlaceholderLabelStyles {
+  NSMutableDictionary *newAttrs = [defaultTypingAttributes mutableCopy];
+  if (_placeholderColor != nullptr) {
+    newAttrs[NSForegroundColorAttributeName] = _placeholderColor;
+  }
+  NSAttributedString *newAttrStr =
+      [[NSAttributedString alloc] initWithString:_placeholderLabel.text
+                                      attributes:newAttrs];
+  _placeholderLabel.attributedText = newAttrStr;
+}
+
+// MARK: - Measuring and states
+
+- (CGSize)measureSize:(CGFloat)maxWidth {
+  // copy the the whole attributed string
+  NSMutableAttributedString *currentStr = [[NSMutableAttributedString alloc]
+      initWithAttributedString:textView.textStorage];
+
+  // edge case: empty input should still be of a height of a single line, so we
+  // add a mock "I" character
+  if ([currentStr length] == 0) {
+    [currentStr
+        appendAttributedString:[[NSAttributedString alloc]
+                                   initWithString:@"I"
+                                       attributes:textView.typingAttributes]];
+  }
+
+  // edge case: input with only a zero width space should still be of a height
+  // of a single line, so we add a mock "I" character
+  if ([currentStr length] == 1 &&
+      [[currentStr.string substringWithRange:NSMakeRange(0, 1)]
+          isEqualToString:@"\u200B"]) {
+    [currentStr
+        appendAttributedString:[[NSAttributedString alloc]
+                                   initWithString:@"I"
+                                       attributes:textView.typingAttributes]];
+  }
+
+  // edge case: trailing newlines aren't counted towards height calculations, so
+  // we add a mock "I" character
+  if (currentStr.length > 0) {
+    unichar lastChar =
+        [currentStr.string characterAtIndex:currentStr.length - 1];
+    if ([[NSCharacterSet newlineCharacterSet] characterIsMember:lastChar]) {
+      [currentStr
+          appendAttributedString:[[NSAttributedString alloc]
+                                     initWithString:@"I"
+                                         attributes:defaultTypingAttributes]];
+    }
+  }
+
+  CGRect boundingBox =
+      [currentStr boundingRectWithSize:CGSizeMake(maxWidth, CGFLOAT_MAX)
+                               options:NSStringDrawingUsesLineFragmentOrigin |
+                                       NSStringDrawingUsesFontLeading
+                               context:nullptr];
+
+  return CGSizeMake(maxWidth, ceil(boundingBox.size.height));
 }
 
 // make sure the newest state is kept in _state property
@@ -850,42 +939,18 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
   // componentView) so we need to run a single height calculation for any
   // initial values
   if (oldState == nullptr) {
-    [self commitSize:textView.textContainer.size];
+    [self tryUpdatingHeight];
   }
 }
 
-- (void)commitSize:(CGSize)size {
+- (void)tryUpdatingHeight {
   if (_state == nullptr) {
     return;
   }
-
+  _componentViewHeightUpdateCounter++;
   auto selfRef = wrapManagedObjectWeakly(self);
-  facebook::react::Size newSize{.width = size.width, .height = size.height};
   _state->updateState(
-      facebook::react::EnrichedTextInputViewState(newSize, selfRef));
-}
-
-- (CGSize)measureInitialSizeWithMaxWidth:(CGFloat)maxWidth {
-  NSTextContainer *container = textView.textContainer;
-  NSLayoutManager *layoutManager = textView.layoutManager;
-
-  container.size = CGSizeMake(maxWidth, CGFLOAT_MAX);
-
-  [layoutManager ensureLayoutForTextContainer:container];
-
-  CGRect used = [layoutManager usedRectForTextContainer:container];
-  CGFloat height = ceil(used.size.height);
-
-  // Empty text fallback
-  if (textView.textStorage.length == 0) {
-    UIFont *font =
-        textView.typingAttributes[NSFontAttributeName] ?: textView.font;
-    if (font) {
-      height = ceil(font.lineHeight);
-    }
-  }
-
-  return CGSizeMake(maxWidth, height);
+      EnrichedTextInputViewState(_componentViewHeightUpdateCounter, selfRef));
 }
 
 // MARK: - Active styles
@@ -1607,7 +1672,12 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
   }
 
   // placholder management
-  [textView updatePlaceholderVisibility];
+  if (!_placeholderLabel.hidden && textView.textStorage.string.length > 0) {
+    [self setPlaceholderLabelShown:NO];
+  } else if (textView.textStorage.string.length == 0 &&
+             _placeholderLabel.hidden) {
+    [self setPlaceholderLabelShown:YES];
+  }
 
   if (![textView.textStorage.string isEqualToString:_recentInputString]) {
     // modified words handling
@@ -1643,9 +1713,57 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
     }
   }
 
+  // update height on each character change
+  [self tryUpdatingHeight];
   // update active styles as well
   [self tryUpdatingActiveStyles];
   [self layoutAttachments];
+  // update drawing - schedule debounced relayout
+  [self scheduleRelayoutIfNeeded];
+}
+
+// Debounced relayout helper - coalesces multiple requests into one per runloop
+// tick
+- (void)scheduleRelayoutIfNeeded {
+  // Cancel any previously scheduled invocation to debounce
+  [NSObject cancelPreviousPerformRequestsWithTarget:self
+                                           selector:@selector(_performRelayout)
+                                             object:nil];
+  // Schedule on next runloop cycle
+  [self performSelector:@selector(_performRelayout)
+             withObject:nil
+             afterDelay:0];
+}
+
+- (void)_performRelayout {
+  if (!textView) {
+    return;
+  }
+
+  dispatch_async(dispatch_get_main_queue(), ^{
+    NSRange wholeRange =
+        NSMakeRange(0, self->textView.textStorage.string.length);
+    NSRange actualRange = NSMakeRange(0, 0);
+    [self->textView.layoutManager
+        invalidateLayoutForCharacterRange:wholeRange
+                     actualCharacterRange:&actualRange];
+    [self->textView.layoutManager ensureLayoutForCharacterRange:actualRange];
+    [self->textView.layoutManager
+        invalidateDisplayForCharacterRange:wholeRange];
+
+    // We have to explicitly set contentSize
+    // That way textView knows if content overflows and if should be scrollable
+    // We recall measureSize here because value returned from previous
+    // measureSize may not be up-to date at that point
+    CGSize measuredSize = [self measureSize:self->textView.frame.size.width];
+    self->textView.contentSize = measuredSize;
+  });
+}
+
+- (void)didMoveToWindow {
+  [super didMoveToWindow];
+  // used to run all lifecycle callbacks
+  [self anyTextMayHaveBeenModified];
 }
 
 // MARK: - UITextView delegate methods
@@ -1821,7 +1939,7 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
     defaultTypingAttributes = newTypingAttrs;
     textView.typingAttributes = defaultTypingAttributes;
 
-    [textView refreshPlaceholder];
+    [self refreshPlaceholderLabelStyles];
 
     NSRange prevSelectedRange = textView.selectedRange;
 

--- a/ios/inputTextView/InputTextView.h
+++ b/ios/inputTextView/InputTextView.h
@@ -3,8 +3,4 @@
 
 @interface InputTextView : UITextView
 @property(nonatomic, weak) id input;
-@property(nonatomic, copy, nullable) NSString *placeholderText;
-@property(nonatomic, strong, nullable) UIColor *placeholderColor;
-- (void)updatePlaceholderVisibility;
-- (void)refreshPlaceholder;
 @end

--- a/ios/inputTextView/InputTextView.mm
+++ b/ios/inputTextView/InputTextView.mm
@@ -4,27 +4,7 @@
 #import "TextInsertionUtils.h"
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
-@implementation InputTextView {
-  UILabel *_placeholderView;
-  CGSize _lastCommittedSize;
-};
-
-- (instancetype)initWithFrame:(CGRect)frame {
-  if ((self = [super initWithFrame:frame])) {
-    _placeholderView = [[UILabel alloc] initWithFrame:self.bounds];
-    _placeholderView.isAccessibilityElement = NO;
-    _placeholderView.numberOfLines = 0;
-    _placeholderView.adjustsFontForContentSizeCategory = YES;
-    [self addSubview:_placeholderView];
-
-    self.textContainer.lineFragmentPadding = 0;
-    self.scrollEnabled = YES;
-    self.scrollsToTop = NO;
-    self.alwaysBounceVertical = YES;
-    _lastCommittedSize = CGSizeZero;
-  }
-  return self;
-}
+@implementation InputTextView
 
 - (void)copy:(id)sender {
   EnrichedTextInputView *typedInput = (EnrichedTextInputView *)_input;
@@ -278,79 +258,6 @@
                     withSelection:YES];
 
   [typedInput anyTextMayHaveBeenModified];
-}
-
-- (void)updatePlaceholderVisibility {
-  BOOL shouldShow =
-      self.placeholderText.length > 0 && self.textStorage.length == 0;
-
-  _placeholderView.hidden = !shouldShow;
-}
-
-- (void)setText:(NSString *)text {
-  [super setText:text];
-  [self updatePlaceholderVisibility];
-}
-
-- (void)setAttributedText:(NSAttributedString *)attributedText {
-  [super setAttributedText:attributedText];
-  [self updatePlaceholderVisibility];
-}
-
-- (void)setPlaceholderText:(NSString *)newPlaceholderText {
-  _placeholderText = newPlaceholderText;
-  [self refreshPlaceholder];
-}
-
-- (void)refreshPlaceholder {
-  EnrichedTextInputView *typedInput = (EnrichedTextInputView *)_input;
-  if (typedInput == nullptr) {
-    return;
-  }
-
-  NSMutableDictionary *attributes =
-      [typedInput->defaultTypingAttributes mutableCopy];
-
-  if (_placeholderColor) {
-    attributes[NSForegroundColorAttributeName] = _placeholderColor;
-  }
-
-  NSString *placeholder = _placeholderText ?: @"";
-
-  _placeholderView.attributedText =
-      [[NSAttributedString alloc] initWithString:placeholder
-                                      attributes:attributes];
-
-  [self updatePlaceholderVisibility];
-
-  [self setNeedsLayout];
-}
-
-- (void)layoutSubviews {
-  [super layoutSubviews];
-
-  CGRect textFrame =
-      UIEdgeInsetsInsetRect(self.bounds, self.textContainerInset);
-
-  CGFloat placeholderHeight =
-      [_placeholderView sizeThatFits:textFrame.size].height;
-
-  textFrame.size.height = MIN(placeholderHeight, textFrame.size.height);
-
-  _placeholderView.frame = textFrame;
-
-  CGRect usedRect =
-      [self.layoutManager usedRectForTextContainer:self.textContainer];
-
-  CGSize newSize = usedRect.size;
-
-  if (CGSizeEqualToSize(newSize, _lastCommittedSize)) {
-    return;
-  }
-
-  _lastCommittedSize = newSize;
-
-  [_input commitSize:newSize];
 }
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender {

--- a/ios/internals/EnrichedTextInputViewShadowNode.h
+++ b/ios/internals/EnrichedTextInputViewShadowNode.h
@@ -17,7 +17,6 @@ class EnrichedTextInputViewShadowNode
     : public ConcreteViewShadowNode<
           EnrichedTextInputViewComponentName, EnrichedTextInputViewProps,
           EnrichedTextInputViewEventEmitter, EnrichedTextInputViewState> {
-
 public:
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
   EnrichedTextInputViewShadowNode(const ShadowNodeFragment &fragment,
@@ -26,7 +25,6 @@ public:
   EnrichedTextInputViewShadowNode(const ShadowNode &sourceShadowNode,
                                   const ShadowNodeFragment &fragment);
   void dirtyLayoutIfNeeded();
-
   Size
   measureContent(const LayoutContext &layoutContext,
                  const LayoutConstraints &layoutConstraints) const override;
@@ -39,7 +37,7 @@ public:
   }
 
 private:
-  mutable Size _prevContentSize{NAN, NAN};
+  int localForceHeightRecalculationCounter_;
   id setupMockTextInputView_() const;
 };
 

--- a/ios/internals/EnrichedTextInputViewShadowNode.mm
+++ b/ios/internals/EnrichedTextInputViewShadowNode.mm
@@ -1,5 +1,5 @@
 #import "EnrichedTextInputViewShadowNode.h"
-
+#import "CoreText/CoreText.h"
 #import <EnrichedTextInputView.h>
 #import <React/RCTShadowView+Layout.h>
 #import <react/utils/ManagedObjectWrapper.h>
@@ -10,16 +10,15 @@ namespace facebook::react {
 extern const char EnrichedTextInputViewComponentName[] =
     "EnrichedTextInputView";
 
-void EnrichedTextInputViewShadowNode::dirtyLayoutIfNeeded() {
-  const auto &state = getStateData();
-  const auto nextSize = state.getContentSize();
-
-  if (_prevContentSize != nextSize) {
-    _prevContentSize = nextSize;
-    YGNodeMarkDirty(&yogaNode_);
-  }
+EnrichedTextInputViewShadowNode::EnrichedTextInputViewShadowNode(
+    const ShadowNodeFragment &fragment, const ShadowNodeFamily::Shared &family,
+    ShadowNodeTraits traits)
+    : ConcreteViewShadowNode(fragment, family, traits) {
+  localForceHeightRecalculationCounter_ = 0;
 }
 
+// mock input is used for the first measure calls that need to be done when the
+// real input isn't defined yet
 id EnrichedTextInputViewShadowNode::setupMockTextInputView_() const {
   // it's rendered far away from the viewport
   const int veryFarAway = 20000;
@@ -33,63 +32,72 @@ id EnrichedTextInputViewShadowNode::setupMockTextInputView_() const {
 }
 
 EnrichedTextInputViewShadowNode::EnrichedTextInputViewShadowNode(
-    const ShadowNode &source, const ShadowNodeFragment &fragment)
-    : ConcreteViewShadowNode(source, fragment) {
+    const ShadowNode &sourceShadowNode, const ShadowNodeFragment &fragment)
+    : ConcreteViewShadowNode(sourceShadowNode, fragment) {
+  dirtyLayoutIfNeeded();
+}
 
-  const auto &oldState =
-      static_cast<const EnrichedTextInputViewShadowNode &>(source)
-          .getStateData();
+void EnrichedTextInputViewShadowNode::dirtyLayoutIfNeeded() {
+  const auto state = this->getStateData();
+  const int receivedCounter = state.getForceHeightRecalculationCounter();
 
-  const auto &newState = getStateData();
-
-  const auto &oldSize = oldState.getContentSize();
-  const auto &newSize = newState.getContentSize();
-
-  if (newSize != oldSize) {
+  if (receivedCounter > localForceHeightRecalculationCounter_) {
+    localForceHeightRecalculationCounter_ = receivedCounter;
     YGNodeMarkDirty(&yogaNode_);
   }
 }
 
-EnrichedTextInputViewShadowNode::EnrichedTextInputViewShadowNode(
-    const ShadowNodeFragment &fragment, const ShadowNodeFamily::Shared &family,
-    ShadowNodeTraits traits)
-    : ConcreteViewShadowNode(fragment, family, traits) {
-  _prevContentSize = {};
-}
-
 Size EnrichedTextInputViewShadowNode::measureContent(
-    const LayoutContext &, const LayoutConstraints &constraints) const {
+    const LayoutContext &layoutContext,
+    const LayoutConstraints &layoutConstraints) const {
   const auto state = this->getStateData();
   const auto componentRef = state.getComponentViewRef();
   RCTInternalGenericWeakWrapper *weakWrapper =
       (RCTInternalGenericWeakWrapper *)unwrapManagedObject(componentRef);
+
   if (weakWrapper != nullptr) {
     id componentObject = weakWrapper.object;
     EnrichedTextInputView *typedComponentObject =
         (EnrichedTextInputView *)componentObject;
 
     if (typedComponentObject != nullptr) {
-      auto size = state.getContentSize();
-      _prevContentSize = size;
-      return constraints.clamp(size);
+      __block CGSize estimatedSize;
+
+      // synchronously dispatch to main thread if needed
+      if ([NSThread isMainThread]) {
+        estimatedSize = [typedComponentObject
+            measureSize:layoutConstraints.maximumSize.width];
+      } else {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+          estimatedSize = [typedComponentObject
+              measureSize:layoutConstraints.maximumSize.width];
+        });
+      }
+
+      return {estimatedSize.width,
+              MIN(estimatedSize.height, layoutConstraints.maximumSize.height)};
     }
-  }
-  __block CGSize estimatedSize;
-  // synchronously dispatch to main thread if needed
-  if ([NSThread isMainThread]) {
-    EnrichedTextInputView *mockTextInputView = setupMockTextInputView_();
-    estimatedSize = [mockTextInputView
-        measureInitialSizeWithMaxWidth:constraints.maximumSize.width];
   } else {
-    dispatch_sync(dispatch_get_main_queue(), ^{
+    __block CGSize estimatedSize;
+
+    // synchronously dispatch to main thread if needed
+    if ([NSThread isMainThread]) {
       EnrichedTextInputView *mockTextInputView = setupMockTextInputView_();
-      estimatedSize = [mockTextInputView
-          measureInitialSizeWithMaxWidth:constraints.maximumSize.width];
-    });
+      estimatedSize =
+          [mockTextInputView measureSize:layoutConstraints.maximumSize.width];
+    } else {
+      dispatch_sync(dispatch_get_main_queue(), ^{
+        EnrichedTextInputView *mockTextInputView = setupMockTextInputView_();
+        estimatedSize =
+            [mockTextInputView measureSize:layoutConstraints.maximumSize.width];
+      });
+    }
+
+    return {estimatedSize.width,
+            MIN(estimatedSize.height, layoutConstraints.maximumSize.height)};
   }
 
-  return {estimatedSize.width,
-          MIN(estimatedSize.height, constraints.maximumSize.height)};
+  return Size();
 }
 
 } // namespace facebook::react

--- a/ios/internals/EnrichedTextInputViewState.cpp
+++ b/ios/internals/EnrichedTextInputViewState.cpp
@@ -1,0 +1,10 @@
+#include "EnrichedTextInputViewState.h"
+
+namespace facebook::react {
+int EnrichedTextInputViewState::getForceHeightRecalculationCounter() const {
+  return forceHeightRecalculationCounter_;
+}
+std::shared_ptr<void> EnrichedTextInputViewState::getComponentViewRef() const {
+  return componentViewRef_;
+}
+} // namespace facebook::react

--- a/ios/internals/EnrichedTextInputViewState.h
+++ b/ios/internals/EnrichedTextInputViewState.h
@@ -1,24 +1,21 @@
 #pragma once
-#include <react/renderer/graphics/Size.h>
+#include <memory>
 
 namespace facebook::react {
 
 class EnrichedTextInputViewState {
 public:
-  EnrichedTextInputViewState() = default;
-
-  explicit EnrichedTextInputViewState(Size contentSize,
-                                      std::shared_ptr<void> ref)
-      : contentSize_(contentSize), componentViewRef_(std::move(ref)) {}
-
-  const Size &getContentSize() const { return contentSize_; }
-
-  const std::shared_ptr<void> getComponentViewRef() const {
-    return componentViewRef_;
+  EnrichedTextInputViewState()
+      : forceHeightRecalculationCounter_(0), componentViewRef_(nullptr) {}
+  EnrichedTextInputViewState(int counter, std::shared_ptr<void> ref) {
+    forceHeightRecalculationCounter_ = counter;
+    componentViewRef_ = ref;
   }
+  int getForceHeightRecalculationCounter() const;
+  std::shared_ptr<void> getComponentViewRef() const;
 
 private:
-  Size contentSize_{};
+  int forceHeightRecalculationCounter_{};
   std::shared_ptr<void> componentViewRef_{};
 };
 


### PR DESCRIPTION
Reverts https://github.com/software-mansion/react-native-enriched/pull/339 due to a iOS layout bug we found;
The input sometimes becomes unscrollable when it's inside a scrollable bottom sheet (`@gorhom/bottom-sheet`), with a `KeyboardAwareScrollView` (`react-native-keyboard-controller`) turned into a proper bottom-sheet-scrollview component. 

The bug doesn't appear when testing a commit before the PR, but does happen on the exact merge commit of the said PR.