### PR TITLE
fix(iOS): prevent extending link styles

### DIFF
--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -1884,6 +1884,14 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
     return NO;
   }
 
+  // Tapping near a link causes iOS to re-derive typingAttributes from
+  // character attributes after textViewDidChangeSelection returns, undoing
+  // the cleanup in manageSelectionBasedChanges. Strip them again here, right
+  // before insertion, so new text never inherits link styling.
+  if (linkStyle != nullptr) {
+    [linkStyle manageLinkTypingAttributes];
+  }
+
   return YES;
 }
 


### PR DESCRIPTION
# Summary

 Prevent extending link styles while tapping on the end of applied link.

## Test Plan

Go to example app create link, tap at the end of the link and type something.
The link styles should not be extended.

## Screenshots / Videos
Before:

https://github.com/user-attachments/assets/daadcaaa-66a3-42e4-af9c-c45c9ecaadeb


After:

https://github.com/user-attachments/assets/988e6555-408e-490c-b716-956f577856bb


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
