### PR TITLE
fix(android): merging and splitting paragraph styles

### DIFF
--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -437,7 +437,7 @@ const htmlStyle: HtmlStyle = {
   codeblock: {
     color: 'green',
     borderRadius: 8,
-    backgroundColor: 'aquamarine',
+    backgroundColor: 'grey',
   },
   code: {
     color: 'purple',


### PR DESCRIPTION
# Summary

Fixes: https://github.com/software-mansion/react-native-enriched/issues/402

## Test Plan

- enter 3 line code block text
- toggle style in second line
- notice that style is removed only for second line

## Screenshots / Videos

https://github.com/user-attachments/assets/62b25441-5a78-4512-9303-cbc8d7f5f3e9

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
