### PR TITLE
fix(Android): removing paragraph styles

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/textinput/styles/ParagraphStyles.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/styles/ParagraphStyles.kt
@@ -221,11 +221,7 @@ class ParagraphStyles(
     }
 
     val currSpan = currParagraphSpans[0]
-    val nextSpan = getNextParagraphSpan(s, end, type)
-
-    if (nextSpan == null) {
-      return
-    }
+    val nextSpan = getNextParagraphSpan(s, end, type) ?: return
 
     val newStart = s.getSpanStart(currSpan)
     val newEnd = s.getSpanEnd(nextSpan)
@@ -347,9 +343,12 @@ class ParagraphStyles(
           continue
         }
 
+        // If removing text at the beginning of the line, we want to remove the span for the whole paragraph
         if (isBackspace) {
-          endCursorPosition -= 1
+          val currentParagraphBounds = s.getParagraphBounds(endCursorPosition)
+          removeSpansForRange(s, currentParagraphBounds.first, currentParagraphBounds.second, config.clazz)
           spanState.setStart(style, null)
+          continue
         } else {
           s.insert(endCursorPosition, EnrichedConstants.ZWS_STRING)
           endCursorPosition += 1


### PR DESCRIPTION
# Summary

Fixes removing paragraph continuous styles by using backspace.

## Test Plan

- Enter multiline code block or blockquote
- Remove text from the second line
- Notice that styles are still applied to other lines, but there is no style for second line

## Screenshots / Videos

### Before

https://github.com/user-attachments/assets/bfd6ff7b-0146-4770-b9b9-158b80d65108

### After

https://github.com/user-attachments/assets/18789024-625b-4f88-b665-c7d93feef9fc

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
