### PR TITLE
fix(iOS): nil `NSParagraphStyle` crashes

### DIFF
--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -291,50 +291,6 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
   _placeholderLabel.adjustsFontForContentSizeCategory = YES;
 }
 
-// MARK: - Paragraph style helpers
-
-- (void)applyLineHeight:(NSMutableDictionary *)typingAttributes {
-  CGFloat rawLineHeight = [config primaryLineHeight];
-  NSUInteger length = textView.textStorage.string.length;
-  if (length == 0) {
-    return;
-  }
-
-  CGFloat scaledLineHeight = 0;
-  if (rawLineHeight > 0) {
-    // Scale lineHeight with the same Dynamic Type factor used for font sizes.
-    scaledLineHeight =
-        [[UIFontMetrics defaultMetrics] scaledValueForValue:rawLineHeight];
-  }
-
-  NSRange fullRange = NSMakeRange(0, length);
-
-  // apply lineHeight over the entire text storage content
-  [textView.textStorage
-      enumerateAttribute:NSParagraphStyleAttributeName
-                 inRange:fullRange
-                 options:0
-              usingBlock:^(id _Nullable value, NSRange range,
-                           BOOL *_Nonnull stop) {
-                NSMutableParagraphStyle *pStyle;
-                if (value != nil) {
-                  pStyle = [(NSParagraphStyle *)value mutableCopy];
-                } else {
-                  pStyle = [[NSMutableParagraphStyle alloc] init];
-                }
-                pStyle.minimumLineHeight = scaledLineHeight;
-                [textView.textStorage addAttribute:NSParagraphStyleAttributeName
-                                             value:pStyle
-                                             range:range];
-              }];
-
-  // apply lineHeight to typing attributes
-  NSMutableParagraphStyle *paragraphStyle =
-      [[NSMutableParagraphStyle alloc] init];
-  paragraphStyle.minimumLineHeight = scaledLineHeight;
-  typingAttributes[NSParagraphStyleAttributeName] = paragraphStyle;
-}
-
 // MARK: - Props
 
 - (void)updateProps:(Props::Shared const &)props
@@ -781,10 +737,16 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
         [config primaryColor];
     defaultTypingAttributes[NSStrikethroughColorAttributeName] =
         [config primaryColor];
-    [self applyLineHeight:defaultTypingAttributes];
+    NSMutableParagraphStyle *defaultPStyle =
+        [[NSMutableParagraphStyle alloc] init];
+    defaultPStyle.minimumLineHeight = [config scaledPrimaryLineHeight];
+    defaultTypingAttributes[NSParagraphStyleAttributeName] = defaultPStyle;
+
     textView.typingAttributes = defaultTypingAttributes;
     textView.selectedRange = prevSelectedRange;
 
+    // make sure the newest lineHeight is applied
+    [self refreshLineHeight];
     // update the placeholder as well
     [self refreshPlaceholderLabelStyles];
   }
@@ -952,6 +914,24 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
       [[NSAttributedString alloc] initWithString:_placeholderLabel.text
                                       attributes:newAttrs];
   _placeholderLabel.attributedText = newAttrStr;
+}
+
+- (void)refreshLineHeight {
+  [textView.textStorage
+      enumerateAttribute:NSParagraphStyleAttributeName
+                 inRange:NSMakeRange(0, textView.textStorage.string.length)
+                 options:0
+              usingBlock:^(id _Nullable value, NSRange range,
+                           BOOL *_Nonnull stop) {
+                NSMutableParagraphStyle *pStyle =
+                    [(NSParagraphStyle *)value mutableCopy];
+                if (pStyle == nil)
+                  return;
+                pStyle.minimumLineHeight = [config scaledPrimaryLineHeight];
+                [textView.textStorage addAttribute:NSParagraphStyleAttributeName
+                                             value:pStyle
+                                             range:range];
+              }];
 }
 
 // MARK: - Measuring and states

--- a/ios/config/InputConfig.h
+++ b/ios/config/InputConfig.h
@@ -12,6 +12,7 @@
 - (void)setPrimaryFontSize:(NSNumber *)newValue;
 - (CGFloat)primaryLineHeight;
 - (void)setPrimaryLineHeight:(CGFloat)newValue;
+- (CGFloat)scaledPrimaryLineHeight;
 - (NSString *)primaryFontWeight;
 - (void)setPrimaryFontWeight:(NSString *)newValue;
 - (NSString *)primaryFontFamily;

--- a/ios/config/InputConfig.mm
+++ b/ios/config/InputConfig.mm
@@ -145,6 +145,11 @@
   _primaryLineHeight = newValue;
 }
 
+- (CGFloat)scaledPrimaryLineHeight {
+  return [[UIFontMetrics defaultMetrics]
+      scaledValueForValue:[self primaryLineHeight]];
+}
+
 - (NSString *)primaryFontWeight {
   return _primaryFontWeight != nullptr
              ? _primaryFontWeight


### PR DESCRIPTION
# Summary

Recent PR with `lineHeight` on iOS removed the line that always set `NSParagraphStyle` in the `defaultTypingAttributes`, which resulted in crashes from the code that relies on always having it there. 
This PR fixes that, as well as simplifies and cleans the code related to the `lineHeight` prop.

## Test Plan

All styles that rely on `NSParagraphStyle` were crashing, so these are; lists, codeblocks, blockquotes, headings. Check them out to see there are no more crashes.

For the `lineHeight` prop, check it out in combination with fast refresh and accessibility font size.

## Screenshots / Videos

https://github.com/user-attachments/assets/b0d8972e-870d-406b-bade-4f804facd6a7

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
