### PR TITLE
fix(iOS): pasting webp images

### DIFF
--- a/ios/inputTextView/InputTextView.mm
+++ b/ios/inputTextView/InputTextView.mm
@@ -74,12 +74,12 @@
       NSString *type = item.allKeys[j];
       if ([type isEqual:UTTypeJPEG.identifier] ||
           [type isEqual:UTTypePNG.identifier] ||
-          [type isEqual:UTTypeWebP.identifier] ||
           [type isEqual:UTTypeHEIC.identifier] ||
           [type isEqual:UTTypeTIFF.identifier]) {
         imageData = [self getDataForImageItem:item[type] type:type];
-      } else if ([type isEqual:UTTypeGIF.identifier]) {
-        // gifs
+      } else if ([type isEqual:UTTypeWebP.identifier] ||
+                 [type isEqual:UTTypeGIF.identifier]) {
+        // webp and gifs: read raw bytes directly — no re-encoding needed
         imageData = [pasteboard dataForPasteboardType:type];
       }
       if (!imageData) {


### PR DESCRIPTION
# Summary

Fixes pasting webp images on iOS. Currently it crashes the app.

## Test Plan

- Copy webp image
- Paste it into `EnrichedTextInput`
- Notice that image is properly pasted.
- Compare with 0.5.0 version where app is crashing in such scenario

## Screenshots / Videos

https://github.com/user-attachments/assets/d3256a39-ae05-42fc-af40-a8eb364ccc5b

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
