### PR TITLE
fix(android): parsing initial html

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputView.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputView.kt
@@ -980,7 +980,8 @@ class EnrichedTextInputView : AppCompatEditText {
     super.onAttachedToWindow()
 
     // https://github.com/facebook/react-native/blob/36df97f500aa0aa8031098caf7526db358b6ddc1/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt#L946
-    super.setTextIsSelectable(true)
+    // setTextIsSelectable internally calls setText(), which fires afterTextChanged that should be marked as a transaction to avoid unwanted side effects
+    runAsATransaction { super.setTextIsSelectable(true) }
 
     if (autoFocus && !didAttachToWindow) {
       requestFocusProgrammatically()


### PR DESCRIPTION
# Summary

Fixes: https://github.com/software-mansion/react-native-enriched/issues/461

## Test Plan

- As a default value provide below html:

```html
<html>
<h1>Lorem</h1>
<h2>Ipsum</h2>
<p>Dolor</p>
</html>
```

- notice that text is properly parsed, no additional headings are inserted
- ensure that selecting text inside recycled view still works fine as described in this [PR](https://github.com/software-mansion/react-native-enriched/pull/343)

## Screenshots / Videos

https://github.com/user-attachments/assets/d2d08064-79b8-4883-aa1a-ceccf175af71

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
