### PR TITLE
fix(iOS): default value scroll

### DIFF
--- a/ios/EnrichedTextInputView.h
+++ b/ios/EnrichedTextInputView.h
@@ -40,6 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)emitOnMentionEvent:(NSString *)indicator text:(nullable NSString *)text;
 - (void)emitOnPasteImagesEvent:(NSArray<NSDictionary *> *)images;
 - (void)anyTextMayHaveBeenModified;
+- (void)scheduleRelayoutIfNeeded;
 - (BOOL)handleStyleBlocksAndConflicts:(StyleType)type range:(NSRange)range;
 - (NSArray<NSNumber *> *)getPresentStyleTypesFrom:(NSArray<NSNumber *> *)types
                                             range:(NSRange)range;

--- a/ios/inputTextView/InputTextView.mm
+++ b/ios/inputTextView/InputTextView.mm
@@ -6,6 +6,17 @@
 
 @implementation InputTextView
 
+- (void)layoutSubviews {
+  [super layoutSubviews];
+  // UITextView resets contentSize during its own layout pass (triggered when
+  // the frame is set on first mount). Re-schedule a relayout so our explicit
+  // contentSize is applied after UITextView finishes its internal layout.
+  EnrichedTextInputView *input = (EnrichedTextInputView *)_input;
+  if (input != nil) {
+    [input scheduleRelayoutIfNeeded];
+  }
+}
+
 - (void)copy:(id)sender {
   EnrichedTextInputView *typedInput = (EnrichedTextInputView *)_input;
   if (typedInput == nullptr) {


### PR DESCRIPTION
# Summary

Fixes iOS input scrolling when provided default value is too long to fit maximum input height.

## Test Plan

- Enter longer `defaultValue`, for the example app below should be enough

```tsx
defaultValue={
  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec suscipit auctor dui, at efficitur velit. Donec a semper nisl. Sed id metus ac enim commodo efficitur. Donec eget ligula a enim efficitur efficitur. Donec sed felis eget nunc convallis varius. Curabitur in mi ut nisl tincidunt commodo. In eleifend, enim in facilisis commodo, odio nisl faucibus enim, sed efficitur nisi nisl et nunc. Proin ac sem ut ipsum varius fringilla. Donec eget est a sapien efficitur convallis. Donec ac odio ac justo efficitur fermentum. Donec vel nibh a felis efficitur cursus.'
}
```

- Refresh the app
- Notice that input is scrollable

## Screenshots / Videos

https://github.com/user-attachments/assets/fe2ec476-6ddf-4c8d-b76a-2f9ea60d8ed8

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
