### PR TITLE
fix: content is clipped when lineHeight is set

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputView.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputView.kt
@@ -347,6 +347,7 @@ class EnrichedTextInputView : AppCompatEditText {
       // Scroll to the last line of text
       setSelection(text?.length ?: 0)
     }
+    layoutManager.invalidateLayout()
   }
 
   fun setCustomSelection(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Fixes: #456 

This PR adds `invalidateLayout` after applying `lineHeight` inside setValue

## Test Plan
You can find reproduction steps inside #456 issue.

## Screenshots / Videos
Before:

https://github.com/user-attachments/assets/5c76e46b-645c-416a-b48e-bbfed75320bb

After:

https://github.com/user-attachments/assets/9be17212-21c8-4fc4-b21f-74ca6d386624


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
