### PR TITLE
 Set up publish workflow that can be used for both nightly and manual release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,9 +38,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: .nvmrc
+          node-version-file: .nvmrc
           cache: 'yarn'
           registry-url: https://registry.npmjs.org/
 


### PR DESCRIPTION
# Summary

This PR refactor `publish.yml` and uses `npm-package-publish` for nightly and manual publish.

Job success: https://github.com/software-mansion/react-native-enriched/actions/runs/22892021685/job/66417143113

## Test Plan

Run Publish workflow