### PR TITLE
fix(iOS): redundant check in headings parsing

### DIFF
--- a/ios/inputParser/InputParser.mm
+++ b/ios/inputParser/InputParser.mm
@@ -1378,21 +1378,18 @@
       mentionParams.attributes = formattedAttrsString;
 
       stylePair.styleValue = mentionParams;
-    } else if ([[tagName substringWithRange:NSMakeRange(0, 1)]
-                   isEqualToString:@"h"]) {
-      if ([tagName isEqualToString:@"h1"]) {
-        [styleArr addObject:@([H1Style getStyleType])];
-      } else if ([tagName isEqualToString:@"h2"]) {
-        [styleArr addObject:@([H2Style getStyleType])];
-      } else if ([tagName isEqualToString:@"h3"]) {
-        [styleArr addObject:@([H3Style getStyleType])];
-      } else if ([tagName isEqualToString:@"h4"]) {
-        [styleArr addObject:@([H4Style getStyleType])];
-      } else if ([tagName isEqualToString:@"h5"]) {
-        [styleArr addObject:@([H5Style getStyleType])];
-      } else if ([tagName isEqualToString:@"h6"]) {
-        [styleArr addObject:@([H6Style getStyleType])];
-      }
+    } else if ([tagName isEqualToString:@"h1"]) {
+      [styleArr addObject:@([H1Style getStyleType])];
+    } else if ([tagName isEqualToString:@"h2"]) {
+      [styleArr addObject:@([H2Style getStyleType])];
+    } else if ([tagName isEqualToString:@"h3"]) {
+      [styleArr addObject:@([H3Style getStyleType])];
+    } else if ([tagName isEqualToString:@"h4"]) {
+      [styleArr addObject:@([H4Style getStyleType])];
+    } else if ([tagName isEqualToString:@"h5"]) {
+      [styleArr addObject:@([H5Style getStyleType])];
+    } else if ([tagName isEqualToString:@"h6"]) {
+      [styleArr addObject:@([H6Style getStyleType])];
     } else if ([tagName isEqualToString:@"ul"]) {
       if ([self isUlCheckboxList:params]) {
         [styleArr addObject:@([CheckboxListStyle getStyleType])];


### PR DESCRIPTION
# Summary

On iOS, `react-native-enriched` can crash when pasting text copied from the ChatGPT app into `EnrichedTextInput`.

The ChatGPT app places full HTML on the pasteboard, including a `<head>` section. In the iOS parser, heading detection was too broad and treated any tag starting with `h` as a heading candidate. That causes `<head>` to enter the heading branch even though only `h1`-`h6` are supported.

As a result, the parser builds malformed style data and later crashes with:

```text
NSRangeException: *** -[__NSArrayM objectAtIndexedSubscript:]: index 1 beyond bounds [0 .. 0]
```

**Root Cause**

The iOS parser matched tags by checking whether the tag name started with `h`, instead of matching only supported heading tags. Because of that, `<head>` was treated like a heading-related tag, which produced an invalid parsed style entry and caused the crash later in processing.

**Fix**

Restrict heading handling on iOS to exact matches for `h1`, `h2`, `h3`, `h4`, `h5`, and `h6` only. This prevents `<head>` and other unrelated `h*` tags from being misclassified.

## Test Plan

1. Copy formatted text from the ChatGPT iOS (or macOS) app.
2. Paste it into `EnrichedTextInput` on iOS.
3. The app crashes during HTML parsing.

**Example clipboard HTML from ChatGPT**

```html
<html>
<head>
<meta charset="UTF-8">
</head>
<body>

<p class="p1">Some text</p>

</body>
</html>
```


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
