### PR TITLE
fix(iOS): body tag handling crash

### DIFF
--- a/ios/inputParser/InputParser.mm
+++ b/ios/inputParser/InputParser.mm
@@ -772,18 +772,24 @@
       if (normalized != nil) {
         fixedHtml = normalized;
       }
-    } else {
-      // in other case we are most likely working with some external html - try
-      // getting the styles from between body tags
-      NSRange openingBodyRange = [htmlWithoutSpaces rangeOfString:@"<body>"];
-      NSRange closingBodyRange = [htmlWithoutSpaces rangeOfString:@"</body>"];
+    }
 
-      if (openingBodyRange.length != 0 && closingBodyRange.length != 0) {
-        NSInteger newStart = openingBodyRange.location + 7;
-        NSInteger newEnd = closingBodyRange.location - 1;
-        fixedHtml = [htmlWithoutSpaces
-            substringWithRange:NSMakeRange(newStart, newEnd - newStart + 1)];
-      }
+    // Additionally, try getting the content from between body tags if there are
+    // some:
+
+    // Firstly make sure there are no newlines between them.
+    fixedHtml = [fixedHtml stringByReplacingOccurrencesOfString:@"<body>\n"
+                                                     withString:@"<body>"];
+    fixedHtml = [fixedHtml stringByReplacingOccurrencesOfString:@"\n</body>"
+                                                     withString:@"</body>"];
+    // Then, if there actually are body tags, use the content between them.
+    NSRange openingBodyRange = [htmlWithoutSpaces rangeOfString:@"<body>"];
+    NSRange closingBodyRange = [htmlWithoutSpaces rangeOfString:@"</body>"];
+    if (openingBodyRange.length != 0 && closingBodyRange.length != 0) {
+      NSInteger newStart = openingBodyRange.location + 6;
+      NSInteger newEnd = closingBodyRange.location - 1;
+      fixedHtml = [htmlWithoutSpaces
+          substringWithRange:NSMakeRange(newStart, newEnd - newStart + 1)];
     }
   }
 


### PR DESCRIPTION
# Summary

Fixes https://github.com/software-mansion/react-native-enriched/pull/479.

We were handling htmls with `body` tags only if we had no `html` tags or didn't use `htmlNormalizer`. Now it is always being handled after either of these steps, which fixes the crash.
Also improved the way it handles newlines around `body` tags, because it previously just always assumed they are there.

## Test Plan

Try pasting the following HTML via example app's `insert html` and see that it properly works with and without `useHtmlNormalizer`:

```html
<html>
<head>
<meta charset="UTF-8">
</head>
<body>

<p class="p1">Some text</p>

</body>
</html>
```

## Screenshots / Videos

- 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
