### PR TITLE
chore: upgrade min maestro version

### DIFF
--- a/.maestro/scripts/run-tests.sh
+++ b/.maestro/scripts/run-tests.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-MIN_MAESTRO_VERSION="2.2.0"
+MIN_MAESTRO_VERSION="2.3.0"
 
 if ! command -v maestro >/dev/null 2>&1; then
   echo "Error: maestro CLI not found." >&2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ We use [Maestro](https://maestro.mobile.dev/) for end-to-end testing. Flows live
 
 #### Prerequisites
 
-- **Maestro CLI** (v2.2.0+) - follow the [Getting Started guide](https://github.com/mobile-dev-inc/maestro?tab=readme-ov-file#getting-started). After installing, ensure `~/.maestro/bin` is in your `PATH`.
+- **Maestro CLI** (v2.3.0+) - follow the [Getting Started guide](https://github.com/mobile-dev-inc/maestro?tab=readme-ov-file#getting-started). After installing, ensure `~/.maestro/bin` is in your `PATH`.
 - **iOS** - Xcode. Ensure `xcrun` is available (it ships with Xcode Command Line Tools).
 - **Android** - Android SDK with SDK Command-line Tools, SDK Platform-Tools, Emulator. Set up `ANDROID_HOME` (typically `$HOME/Library/Android/sdk` on macOS) and ensure the following are in your `PATH`:
   - `$ANDROID_HOME/cmdline-tools/latest/bin`


### PR DESCRIPTION
# Summary

Maestro [2.3.0](https://github.com/mobile-dev-inc/maestro/blob/main/CHANGELOG.md#230) added a fix to `assertScreenshot` that makes the assertion fail when the current screenshot and baseline image have different dimensions. From now on we will require for Maestro to be at least version 2.3.0.

## Test Plan

+ Try to run tests with Maestro v2.2.0
+ Upgrade Maestro to v2.3.0
+ See if tests pass

## Screenshots / Videos

N/A

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
