### PR TITLE
feat: add mentionStyleRules for attribute-based mention styling

### DIFF
--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -698,6 +698,11 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
                          getComplexPropsFromFollyDynamic:newMentionStyle]];
     }
 
+    // Parse mentionStyleRules (embedded as __rules__ in the mention dict)
+    [newConfig setMentionStyleRules:
+                   [MentionStyleProps
+                       getStyleRulesFromFollyDynamic:newMentionStyle]];
+
     stylePropChanged = YES;
   }
 

--- a/ios/config/InputConfig.h
+++ b/ios/config/InputConfig.h
@@ -79,7 +79,10 @@
 - (TextDecorationLineEnum)linkDecorationLine;
 - (void)setLinkDecorationLine:(TextDecorationLineEnum)newValue;
 - (void)setMentionStyleProps:(NSDictionary *)newValue;
+- (void)setMentionStyleRules:(NSArray *)newValue;
 - (MentionStyleProps *)mentionStylePropsForIndicator:(NSString *)indicator;
+- (MentionStyleProps *)mentionStylePropsForIndicator:(NSString *)indicator
+                                          attributes:(NSString *)attributes;
 - (UIColor *)codeBlockFgColor;
 - (void)setCodeBlockFgColor:(UIColor *)newValue;
 - (UIColor *)codeBlockBgColor;

--- a/ios/config/InputConfig.mm
+++ b/ios/config/InputConfig.mm
@@ -43,6 +43,7 @@
   UIColor *_linkColor;
   TextDecorationLineEnum _linkDecorationLine;
   NSDictionary *_mentionProperties;
+  NSArray *_mentionStyleRules;
   UIColor *_codeBlockFgColor;
   CGFloat _codeBlockBorderRadius;
   UIColor *_codeBlockBgColor;
@@ -104,6 +105,7 @@
   copy->_linkColor = [_linkColor copy];
   copy->_linkDecorationLine = [_linkDecorationLine copy];
   copy->_mentionProperties = [_mentionProperties mutableCopy];
+  copy->_mentionStyleRules = [_mentionStyleRules copy];
   copy->_codeBlockFgColor = [_codeBlockFgColor copy];
   copy->_codeBlockBgColor = [_codeBlockBgColor copy];
   copy->_codeBlockBorderRadius = _codeBlockBorderRadius;
@@ -468,6 +470,10 @@
   _mentionProperties = [newValue mutableCopy];
 }
 
+- (void)setMentionStyleRules:(NSArray *)newValue {
+  _mentionStyleRules = [newValue copy];
+}
+
 - (MentionStyleProps *)mentionStylePropsForIndicator:(NSString *)indicator {
   if (_mentionProperties.count == 1 && _mentionProperties[@"all"] != nullptr) {
     // single props for all the indicators
@@ -480,6 +486,36 @@
   fallbackProps.backgroundColor = [UIColor yellowColor];
   fallbackProps.decorationLine = DecorationUnderline;
   return fallbackProps;
+}
+
+- (MentionStyleProps *)mentionStylePropsForIndicator:(NSString *)indicator
+                                          attributes:(NSString *)attributes {
+  // Check mentionStyleRules first — first matching rule wins
+  if (_mentionStyleRules.count > 0 && attributes.length > 0) {
+    NSData *data = [attributes dataUsingEncoding:NSUTF8StringEncoding];
+    NSDictionary *attrDict =
+        [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+
+    if (attrDict) {
+      for (NSDictionary *rule in _mentionStyleRules) {
+        NSDictionary *match = rule[@"match"];
+        MentionStyleProps *style = rule[@"style"];
+        if (!match || !style) continue;
+
+        BOOL allMatch = YES;
+        for (NSString *key in match) {
+          if (![attrDict[key] isEqualToString:match[key]]) {
+            allMatch = NO;
+            break;
+          }
+        }
+        if (allMatch) return style;
+      }
+    }
+  }
+
+  // Fall back to indicator-based lookup
+  return [self mentionStylePropsForIndicator:indicator];
 }
 
 - (UIColor *)codeBlockFgColor {

--- a/ios/interfaces/MentionStyleProps.h
+++ b/ios/interfaces/MentionStyleProps.h
@@ -10,4 +10,5 @@
 @property TextDecorationLineEnum decorationLine;
 + (NSDictionary *)getSinglePropsFromFollyDynamic:(folly::dynamic)folly;
 + (NSDictionary *)getComplexPropsFromFollyDynamic:(folly::dynamic)folly;
++ (NSArray *)getStyleRulesFromFollyDynamic:(folly::dynamic)folly;
 @end

--- a/ios/interfaces/MentionStyleProps.mm
+++ b/ios/interfaces/MentionStyleProps.mm
@@ -51,6 +51,7 @@
   for (const auto &obj : folly.items()) {
     if (obj.first.isString() && obj.second.isObject()) {
       std::string key = obj.first.asString();
+      if (key == "__rules__") continue; // handled by getStyleRulesFromFollyDynamic
       MentionStyleProps *props = [MentionStyleProps
           getSingleMentionStylePropsFromFollyDynamic:obj.second];
       dict[[NSString fromCppString:key]] = props;
@@ -58,6 +59,41 @@
   }
 
   return dict;
+}
+
++ (NSArray *)getStyleRulesFromFollyDynamic:(folly::dynamic)folly {
+  if (!folly.count("__rules__") || !folly["__rules__"].isArray()) {
+    return @[];
+  }
+
+  NSMutableArray *rules = [[NSMutableArray alloc] init];
+  for (const auto &ruleObj : folly["__rules__"]) {
+    if (!ruleObj.isObject()) continue;
+
+    // Parse match dict
+    NSMutableDictionary *match = [[NSMutableDictionary alloc] init];
+    if (ruleObj.count("match") && ruleObj["match"].isObject()) {
+      for (const auto &kv : ruleObj["match"].items()) {
+        if (kv.first.isString() && kv.second.isString()) {
+          match[[NSString fromCppString:kv.first.asString()]] =
+              [NSString fromCppString:kv.second.asString()];
+        }
+      }
+    }
+
+    // Parse style
+    MentionStyleProps *style = nil;
+    if (ruleObj.count("style") && ruleObj["style"].isObject()) {
+      style = [MentionStyleProps
+          getSingleMentionStylePropsFromFollyDynamic:ruleObj["style"]];
+    }
+
+    if (match.count > 0 && style != nil) {
+      [rules addObject:@{@"match" : match, @"style" : style}];
+    }
+  }
+
+  return rules;
 }
 
 @end

--- a/ios/styles/MentionStyle.mm
+++ b/ios/styles/MentionStyle.mm
@@ -191,7 +191,8 @@ static NSString *const MentionAttributeName = @"MentionAttributeName";
   params.attributes = attributes;
 
   MentionStyleProps *styleProps =
-      [_input->config mentionStylePropsForIndicator:indicator];
+      [_input->config mentionStylePropsForIndicator:indicator
+                                         attributes:attributes];
 
   NSMutableDictionary *newAttrs = [@{
     MentionAttributeName : params,
@@ -231,7 +232,8 @@ static NSString *const MentionAttributeName = @"MentionAttributeName";
   _blockMentionEditing = YES;
 
   MentionStyleProps *styleProps =
-      [_input->config mentionStylePropsForIndicator:params.indicator];
+      [_input->config mentionStylePropsForIndicator:params.indicator
+                                         attributes:params.attributes];
 
   NSMutableDictionary *newAttrs = [@{
     MentionAttributeName : params,

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,17 @@ export interface MentionStyleProperties {
   textDecorationLine?: 'underline' | 'none';
 }
 
+/**
+ * Attribute-based style override for mentions.
+ * When a mention's attributes contain all key-value pairs in `match`,
+ * `style` is applied instead of the indicator-based default.
+ * First matching rule wins.
+ */
+export interface MentionStyleRule {
+  match: Record<string, string>;
+  style: MentionStyleProperties;
+}
+
 export interface HtmlStyle {
   h1?: HeadingStyle;
   h2?: HeadingStyle;
@@ -38,6 +49,7 @@ export interface HtmlStyle {
     textDecorationLine?: 'underline' | 'none';
   };
   mention?: Record<string, MentionStyleProperties> | MentionStyleProperties;
+  mentionStyleRules?: MentionStyleRule[];
   ol?: {
     gapWidth?: number;
     marginLeft?: number;

--- a/src/utils/normalizeHtmlStyle.ts
+++ b/src/utils/normalizeHtmlStyle.ts
@@ -1,6 +1,6 @@
 import { type ColorValue, processColor } from 'react-native';
 import type { HtmlStyleInternal } from '../spec/EnrichedTextInputNativeComponent';
-import type { HtmlStyle, MentionStyleProperties } from '../types';
+import type { HtmlStyle, MentionStyleProperties, MentionStyleRule } from '../types';
 
 const defaultStyle: Required<HtmlStyle> = {
   h1: {
@@ -108,6 +108,20 @@ const convertToHtmlStyleInternal = (
     };
   });
 
+  // Embed mentionStyleRules as __rules__ in the mention dict so they flow
+  // to native through the existing htmlStyle.mention prop (UnsafeMixed).
+  if (style.mentionStyleRules && style.mentionStyleRules.length > 0) {
+    (mentionStyles as any).__rules__ = style.mentionStyleRules.map(
+      (rule: MentionStyleRule) => ({
+        match: rule.match,
+        style: {
+          ...defaultStyle.mention,
+          ...rule.style,
+        },
+      })
+    );
+  }
+
   let markerFontWeight: string | undefined;
   if (style.ol?.markerFontWeight) {
     if (typeof style.ol?.markerFontWeight === 'number') {
@@ -166,6 +180,17 @@ const parseColors = (style: HtmlStyleInternal): HtmlStyleInternal => {
 
     if (tagName === 'mention') {
       for (const [indicator, mentionStyle] of Object.entries(tagStyle)) {
+        // Handle __rules__ array separately from indicator style objects
+        if (indicator === '__rules__' && Array.isArray(mentionStyle)) {
+          tagStyles.__rules__ = (mentionStyle as any[]).map((rule) => ({
+            match: rule.match,
+            style: Object.fromEntries(
+              Object.entries(rule.style).map(([k, v]) => [k, parseStyle(k, v)])
+            ),
+          }));
+          continue;
+        }
+
         tagStyles[indicator] = {};
 
         for (const [styleName, styleValue] of Object.entries(


### PR DESCRIPTION
Closes #494

## Summary

Adds a new `mentionStyleRules` property to `htmlStyle` that enables conditional mention styling based on custom attributes. This allows consumers to style individual mentions differently without needing separate indicator characters.

See #494 for the full motivation and API design.

### API

```ts
<EnrichedTextInput
  htmlStyle={{
    mention: {
      "@": { color: "blue", backgroundColor: "lightblue", textDecorationLine: "none" },
    },
    mentionStyleRules: [
      {
        match: { pending: "true" },
        style: { color: "orange", backgroundColor: "lightyellow", textDecorationLine: "none" },
      },
    ],
  }}
  mentionIndicators={["@"]}
/>
```

Then when committing a mention with matching attributes:
```ts
ref.current?.setMention("@", "name", { pending: "true" });
// → renders with orange style instead of blue
```

## Implementation (iOS only)

**JS layer:**
- `mentionStyleRules` on `HtmlStyle` type, processed in `normalizeHtmlStyle` (color conversion)
- Embedded as `__rules__` inside the `mention` dict for native transport — no codegen changes needed

**iOS native:**
- `MentionStyleProps` parses `__rules__` from `folly::dynamic`
- `InputConfig` stores rules and exposes `mentionStylePropsForIndicator:attributes:` which deserializes the mention's JSON attributes and matches against rules
- `MentionStyle.mm` uses the attribute-aware lookup in both `addMention` and `addMentionAtRange`

### What's missing (future work)
- Android implementation
- Web implementation
- Tests

## Test plan
- [x] Mentions without matching attributes render with indicator-based style (no regression)
- [x] Mentions with matching attributes render with the rule's style
- [x] Multiple rules: first match wins
- [x] Rules with multiple match keys: all must match
- [x] Empty/no rules: existing behavior unchanged