### PR TITLE
fix(iOS): add error handling in html parsing

### DIFF
--- a/ios/inputParser/InputParser.mm
+++ b/ios/inputParser/InputParser.mm
@@ -609,7 +609,7 @@
            offsetFromBeginning:0
                plainTextLength:plainText.length];
   } @catch (NSException *exception) {
-    RCTLogWarn(@"[EnrichedTextInput]: Failed to parse HTML (%@), falling back "
+    RCTLogWarn(@"[EnrichedTextInput]: Failed to parse HTML: (%@), falling back "
                @"to raw input.",
                exception.reason);
 
@@ -635,7 +635,7 @@
            offsetFromBeginning:range.location
                plainTextLength:plainText.length];
   } @catch (NSException *exception) {
-    RCTLogWarn(@"[EnrichedTextInput]: Failed to parse HTML (%@), falling back "
+    RCTLogWarn(@"[EnrichedTextInput]: Failed to parse HTML: (%@), falling back "
                @"to raw input.",
                exception.reason);
     [TextInsertionUtils replaceText:html
@@ -663,7 +663,7 @@
            offsetFromBeginning:location
                plainTextLength:plainText.length];
   } @catch (NSException *exception) {
-    RCTLogWarn(@"[EnrichedTextInput]: Failed to parse HTML (%@), falling back "
+    RCTLogWarn(@"[EnrichedTextInput]: Failed to parse HTML: (%@), falling back "
                @"to raw input.",
                exception.reason);
     [TextInsertionUtils insertText:html


### PR DESCRIPTION
# Summary

This PR adds error handling in `html` parsing.

## Test Plan
Throw test error from `getTextAndStylesFromHtml` and insert html in example app by "Set input's value" button. 
Expected result:
- The app does not crash
- Pasted html is displayed in input

## Screenshots / Videos

n/a

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
