### PR TITLE
Correct animated WebP frame timing on iOS

### DIFF
--- a/ios/extensions/ImageExtension.h
+++ b/ios/extensions/ImageExtension.h
@@ -9,7 +9,7 @@
 @interface UIImage (ImageExtension)
 
 /*
-        UIImage *animation = [UIImage animatedImageWithAnimatedGIFData:theData];
+        UIImage *animation = [UIImage animatedImageWithData:theData];
 
     I interpret `theData` as an animated image (GIF or WebP).  I create an
    animated `UIImage` using the source images and frame delays from the data.
@@ -28,7 +28,6 @@
    contain frame 0 3/3 = 1 time, then frame 1 9/3 = 3 times, then frame 2
    15/3 = 5 times.  I set `animation.duration` to (3+9+15)/100 = 0.27 seconds.
 */
-+ (UIImage *_Nullable)animatedImageWithAnimatedGIFData:
-    (NSData *_Nonnull)theData;
++ (UIImage *_Nullable)animatedImageWithData:(NSData *_Nonnull)theData;
 
 @end

--- a/ios/extensions/ImageExtension.mm
+++ b/ios/extensions/ImageExtension.mm
@@ -120,8 +120,7 @@ static void releaseImages(const std::vector<CGImageRef> &images) {
   }
 }
 
-static UIImage *
-animatedImageWithAnimatedGIFImageSource(CGImageSourceRef const source) {
+static UIImage *animatedImageWithImageSource(CGImageSourceRef const source) {
   size_t const count = CGImageSourceGetCount(source);
   if (count == 0) {
     return nil;
@@ -146,10 +145,10 @@ animatedImageWithAnimatedGIFImageSource(CGImageSourceRef const source) {
   return animation;
 }
 
-static UIImage *animatedImageWithAnimatedGIFReleasingImageSource(
-    CGImageSourceRef CF_RELEASES_ARGUMENT source) {
+static UIImage *
+animatedImageWithReleasingSource(CGImageSourceRef CF_RELEASES_ARGUMENT source) {
   if (source) {
-    UIImage *const image = animatedImageWithAnimatedGIFImageSource(source);
+    UIImage *const image = animatedImageWithImageSource(source);
     CFRelease(source);
     return image;
   } else {
@@ -157,8 +156,8 @@ static UIImage *animatedImageWithAnimatedGIFReleasingImageSource(
   }
 }
 
-+ (UIImage *)animatedImageWithAnimatedGIFData:(NSData *)data {
-  return animatedImageWithAnimatedGIFReleasingImageSource(
++ (UIImage *)animatedImageWithData:(NSData *)data {
+  return animatedImageWithReleasingSource(
       CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL));
 }
 

--- a/ios/interfaces/ImageAttachment.mm
+++ b/ios/interfaces/ImageAttachment.mm
@@ -83,10 +83,10 @@ static NSCache<NSString *, UIImage *> *ImageAttachmentCache(void) {
     NSData *bytes = [NSData dataWithContentsOfURL:url];
 
     // We pass all image data (including static formats like PNG or JPEG)
-    // through the GIF parser. It safely acts as a universal parser, returning
-    // a single-frame UIImage for static formats and an animated UIImage for
-    // GIFs.
-    UIImage *img = bytes ? [UIImage animatedImageWithAnimatedGIFData:bytes]
+    // through the animated image parser. It safely acts as a universal parser,
+    // returning a single-frame UIImage for static formats and an animated
+    // UIImage for GIFs and WebPs.
+    UIImage *img = bytes ? [UIImage animatedImageWithData:bytes]
                          : [UIImage systemImageNamed:@"photo"];
 
     dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
Working on an editor where I'm inserting animated images. When using animated WebP, the frame timing of the image is off and causes the image to run way too fast.

# Summary

`delayCentisecondsForImageAtIndex` in `ImageExtension.mm` only reads frame delays from `kCGImagePropertyGIFDictionary`. Animated WebP images store their frame delays under `kCGImagePropertyWebPDictionary` instead, so every frame falls through to the hardcoded default of 1 centisecond.

The fix checks `kCGImagePropertyGIFDictionary` first, then falls back to `kCGImagePropertyWebPDictionary` with the corresponding `kCGImagePropertyWebPUnclampedDelayTime` / `kCGImagePropertyWebPDelayTime` keys.

Only impacts `ios/extensions/ImageExtension.mm`

## Test Plan

1. Insert an animated WebP image into an `EnrichedTextInput` via `setImage`
2. Observe the animation playback speed
3. **Before:** animation loops play far too fast (~100x intended speed)
4. **After:** animation loops play at the correct speed, matching how the same image renders in a standard `UIImageView` or `Image` component
5. Verify animated GIFs still play at the correct speed

## Screenshots / Videos

Video unavailable at the moment. 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    n/a     |

Android is unaffected by this change. Cannot validate whether this bug exists under Android as well.

## Checklist

- [x] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
