### PR TITLE
feat: add insertText command

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputView.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputView.kt
@@ -426,6 +426,28 @@ class EnrichedTextInputView :
     layoutManager.invalidateLayout()
   }
 
+  fun insertText(
+    text: String,
+    start: Int,
+    end: Int,
+  ) {
+    val editable = this.text ?: return
+    val replaceStart: Int
+    val replaceEnd: Int
+
+    if (start < 0) {
+      // Use current selection
+      replaceStart = selectionStart
+      replaceEnd = selectionEnd
+    } else {
+      replaceStart = getActualIndex(start)
+      replaceEnd = getActualIndex(end)
+    }
+
+    editable.replace(replaceStart, replaceEnd, text)
+    setSelection(replaceStart + text.length)
+  }
+
   fun setCustomSelection(
     visibleStart: Int,
     visibleEnd: Int,

--- a/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputViewManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputViewManager.kt
@@ -322,6 +322,15 @@ class EnrichedTextInputViewManager :
     view?.setValue(text)
   }
 
+  override fun insertText(
+    view: EnrichedTextInputView?,
+    text: String,
+    start: Int,
+    end: Int,
+  ) {
+    view?.insertText(text, start, end)
+  }
+
   override fun setSelection(
     view: EnrichedTextInputView?,
     start: Int,

--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -1332,6 +1332,11 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
     CGFloat imgHeight = [(NSNumber *)args[2] floatValue];
 
     [self addImage:uri width:imgWidth height:imgHeight];
+  } else if ([commandName isEqualToString:@"insertText"]) {
+    NSString *text = (NSString *)args[0];
+    NSInteger start = [((NSNumber *)args[1]) integerValue];
+    NSInteger end = [((NSNumber *)args[2]) integerValue];
+    [self insertText:text start:start end:end];
   } else if ([commandName isEqualToString:@"setSelection"]) {
     NSInteger start = [((NSNumber *)args[0]) integerValue];
     NSInteger end = [((NSNumber *)args[1]) integerValue];
@@ -1372,6 +1377,28 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
 
   // set selectedRange and check for changes
   textView.selectedRange = NSRange(textView.textStorage.string.length, 0);
+  [self anyTextMayHaveBeenModified];
+}
+
+- (void)insertText:(NSString *)text start:(NSInteger)start end:(NSInteger)end {
+  NSString *currentText = textView.textStorage.string;
+
+  NSRange replaceRange;
+  if (start < 0) {
+    // Use current selection
+    replaceRange = textView.selectedRange;
+  } else {
+    NSUInteger actualStart = [self getActualIndex:start text:currentText];
+    NSUInteger actualEnd = [self getActualIndex:end text:currentText];
+    replaceRange = NSMakeRange(actualStart, actualEnd - actualStart);
+  }
+
+  // Replace the range with the new text, preserving surrounding attributes
+  [textView.textStorage replaceCharactersInRange:replaceRange withString:text];
+
+  // Move cursor to end of inserted text
+  textView.selectedRange = NSMakeRange(replaceRange.location + text.length, 0);
+
   [self anyTextMayHaveBeenModified];
 }
 

--- a/src/native/EnrichedTextInput.tsx
+++ b/src/native/EnrichedTextInput.tsx
@@ -181,6 +181,11 @@ export const EnrichedTextInput = ({
     setValue: (value: string) => {
       Commands.setValue(nullthrows(nativeRef.current), value);
     },
+    insertText: (text: string, start?: number, end?: number) => {
+      const s = start ?? -1;
+      const e = end ?? s;
+      Commands.insertText(nullthrows(nativeRef.current), text, s, e);
+    },
     getHTML: () => {
       return new Promise<string>((resolve, reject) => {
         const requestId = nextHtmlRequestId.current++;

--- a/src/spec/EnrichedTextInputNativeComponent.ts
+++ b/src/spec/EnrichedTextInputNativeComponent.ts
@@ -411,6 +411,12 @@ interface NativeCommands {
   focus: (viewRef: React.ElementRef<ComponentType>) => void;
   blur: (viewRef: React.ElementRef<ComponentType>) => void;
   setValue: (viewRef: React.ElementRef<ComponentType>, text: string) => void;
+  insertText: (
+    viewRef: React.ElementRef<ComponentType>,
+    text: string,
+    start: Int32,
+    end: Int32
+  ) => void;
   setSelection: (
     viewRef: React.ElementRef<ComponentType>,
     start: Int32,
@@ -477,6 +483,7 @@ export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
     'focus',
     'blur',
     'setValue',
+    'insertText',
     'setSelection',
 
     // Text formatting commands

--- a/src/types.ts
+++ b/src/types.ts
@@ -388,6 +388,7 @@ export interface EnrichedTextInputInstance extends NativeMethods {
   focus: () => void;
   blur: () => void;
   setValue: (value: string) => void;
+  insertText: (text: string, start?: number, end?: number) => void;
   setSelection: (start: number, end: number) => void;
   getHTML: () => Promise<string>;
 

--- a/src/web/EnrichedTextInput.tsx
+++ b/src/web/EnrichedTextInput.tsx
@@ -102,6 +102,16 @@ export const EnrichedTextInput = ({
           })
           .run();
       },
+      insertText: (text: string, start?: number, end?: number) => {
+        if (start !== undefined && start >= 0) {
+          const doc = editor.state.doc;
+          const from = nativePosToTiptapPos(doc, start);
+          const to = end !== undefined ? nativePosToTiptapPos(doc, end) : from;
+          editor.chain().focus().insertContentAt({ from, to }, text).run();
+        } else {
+          editor.commands.insertContent(text);
+        }
+      },
       getHTML: () => Promise.resolve(normalizeHtmlFromTiptap(editor.getHTML())),
       toggleBold: () => {},
       toggleItalic: () => {},


### PR DESCRIPTION
# Summary

Adds a new `insertText` command that inserts plain text into the input without replacing existing rich content (images, mentions, etc).

Accepts optional `start` and `end` position parameters (visible indices, skipping ZWSPs). When omitted or set to -1, inserts at the current selection/cursor position.

`setValue` replaces the entire content, and `setImage` replaces the selection with an image, but there's no way to programmatically insert plain text at a position without destroying rich content.

This is intentionally plain-text-only and complements #409 (`insertValue`), which targets rich/HTML content insertion.

```typescript
inputRef.current.insertText(' ');           // insert at cursor
inputRef.current.insertText('hello', 5);    // insert at position 5
inputRef.current.insertText('hi', 2, 5);    // replace range 2-5
```

## Test Plan

1. Insert an inline image via `setImage`
2. Call `insertText(' ')` — a space should appear after the image without destroying it
3. Call `insertText('hello', 0)` — text should be inserted at position 0
4. Call `insertText('x', 2, 5)` — should replace characters 2-5 with 'x'
5. Verify cursor moves to the end of inserted text in all cases

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)