### PR TITLE
fix(iOS): remove unused RCTTextInputUtils.h import

### DIFF
--- a/ios/utils/KeyboardUtils.mm
+++ b/ios/utils/KeyboardUtils.mm
@@ -1,5 +1,4 @@
 #import "KeyboardUtils.h"
-#import "RCTTextInputUtils.h"
 
 @implementation KeyboardUtils
 + (UIReturnKeyType)getUIReturnKeyTypeFromReturnKeyType:


### PR DESCRIPTION

# Summary
Fixes: #539 
Remove unused `RCTTextInputUtils.h` import

## Test Plan

Test if iOS builds properly

## Screenshots / Videos

n/a

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ❌     |

## Checklist

- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
