### PR TITLE
docs: update lineHeight docs

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -477,7 +477,6 @@ Additionally following [TextStyle](https://reactnative.dev/docs/text#style) prop
 - fontWeight
 - lineHeight
 - fontStyle only on Android
-- lineHeight only on iOS
 
 | Type                                                                                                               | Default Value | Platform |
 | ------------------------------------------------------------------------------------------------------------------ | ------------- | -------- |


### PR DESCRIPTION
# Summary

Remove redundant `- lineHeight only on iOS` information from docs

## Test Plan

n/a

## Screenshots / Videos

n/a

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
