### PR TITLE
fix(iOS): formatting stripped when autocorrect applied

### DIFF
--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -1995,8 +1995,9 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
 - (bool)textView:(UITextView *)textView
     shouldChangeTextInRange:(NSRange)range
             replacementText:(NSString *)text {
-  // Capture the attributes of the word being replaced (autocorrect /
-  // predictive) so didProcessEditing: can re-stamp them onto the replacement.
+  // Capture the attributes at range.location that are being replaced
+  // (autocorrect / predictive) so didProcessEditing: can re-stamp them onto the
+  // replacement.
   if (range.length > 0) {
     _capturedAttributesBeforeChange =
         [textView.textStorage attributesAtIndex:range.location
@@ -2199,28 +2200,26 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
                                 editedRange:editedRange
                                       delta:delta];
 
-  // Re-stamp custom meta-attributes captured in shouldChangeTextInRange: onto
-  // the new range so autocorrect/predictive replacements keep their styling.
-  if ((editedMask & NSTextStorageEditedCharacters) != 0 &&
-      _capturedAttributesBeforeChange != nil) {
-    // Skip while an IME composition is in progress; restamp on commit.
-    if (textView.markedTextRange == nil) {
-      NSSet *customKeys = [attributesManager customAttributesKeys];
-      for (NSString *key in _capturedAttributesBeforeChange) {
-        if ([customKeys containsObject:key]) {
-          [textStorage addAttribute:key
-                              value:_capturedAttributesBeforeChange[key]
-                              range:editedRange];
-        }
-      }
-    }
-
-    // Clear after consuming
-    _capturedAttributesBeforeChange = nil;
-  }
-
   // Needed dirty ranges adjustments happen on every character edition.
   if ((editedMask & NSTextStorageEditedCharacters) != 0) {
+    // Re-stamp custom meta-attributes captured in shouldChangeTextInRange: onto
+    // the new range so autocorrect/predictive replacements keep their styling.
+    if (_capturedAttributesBeforeChange != nil) {
+      // Skip while an IME composition is in progress; restamp on commit.
+      if (textView.markedTextRange == nil) {
+        NSSet *customKeys = [attributesManager customAttributesKeys];
+        for (NSString *key in _capturedAttributesBeforeChange) {
+          if ([customKeys containsObject:key]) {
+            [textStorage addAttribute:key
+                                value:_capturedAttributesBeforeChange[key]
+                                range:editedRange];
+          }
+        }
+      }
+
+      // Clear after consuming
+      _capturedAttributesBeforeChange = nil;
+    }
     // Always try shifting dirty ranges (happens only with delta != 0).
     [attributesManager shiftDirtyRangesWithEditedRange:editedRange
                                         changeInLength:delta];

--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -54,6 +54,7 @@ using namespace facebook::react;
   NSMutableDictionary<NSValue *, UIImageView *> *_attachmentViews;
   NSArray<NSDictionary *> *_contextMenuItems;
   NSString *_submitBehavior;
+  NSDictionary<NSAttributedStringKey, id> *_capturedAttributesBeforeChange;
 }
 
 // MARK: - Component utils
@@ -1994,6 +1995,14 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
 - (bool)textView:(UITextView *)textView
     shouldChangeTextInRange:(NSRange)range
             replacementText:(NSString *)text {
+  // Capture the attributes of the word being replaced (autocorrect /
+  // predictive) so didProcessEditing: can re-stamp them onto the replacement.
+  if (range.length > 0) {
+    _capturedAttributesBeforeChange =
+        [textView.textStorage attributesAtIndex:range.location
+                                 effectiveRange:NULL];
+  }
+
   // Check if the user pressed "Enter"
   if ([text isEqualToString:@"\n"]) {
     const bool shouldSubmit = [self textInputShouldSubmitOnReturn];
@@ -2189,6 +2198,26 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
                                  editedMask:editedMask
                                 editedRange:editedRange
                                       delta:delta];
+
+  // Re-stamp custom meta-attributes captured in shouldChangeTextInRange: onto
+  // the new range so autocorrect/predictive replacements keep their styling.
+  if ((editedMask & NSTextStorageEditedCharacters) != 0 &&
+      _capturedAttributesBeforeChange != nil) {
+    // Skip while an IME composition is in progress; restamp on commit.
+    if (textView.markedTextRange == nil) {
+      NSSet *customKeys = [attributesManager customAttributesKeys];
+      for (NSString *key in _capturedAttributesBeforeChange) {
+        if ([customKeys containsObject:key]) {
+          [textStorage addAttribute:key
+                              value:_capturedAttributesBeforeChange[key]
+                              range:editedRange];
+        }
+      }
+    }
+
+    // Clear after consuming
+    _capturedAttributesBeforeChange = nil;
+  }
 
   // Needed dirty ranges adjustments happen on every character edition.
   if ((editedMask & NSTextStorageEditedCharacters) != 0) {

--- a/ios/attributesManager/AttributesManager.h
+++ b/ios/attributesManager/AttributesManager.h
@@ -14,4 +14,5 @@
 - (void)clearRemovedTypingAttributes;
 - (void)manageTypingAttributesWithOnlySelection:(BOOL)onlySelectionChanged;
 - (void)handleDirtyRangesStyling;
+- (NSSet<NSString *> *)customAttributesKeys;
 @end

--- a/ios/attributesManager/AttributesManager.mm
+++ b/ios/attributesManager/AttributesManager.mm
@@ -25,6 +25,9 @@
 
   return self;
 }
+- (NSSet<NSString *> *)customAttributesKeys {
+  return _customAttributesKeys;
+}
 
 - (void)addDirtyRange:(NSRange)range {
   [_dirtyRanges addObject:[NSValue valueWithRange:range]];


### PR DESCRIPTION
# Summary

Fixes: #548 

This PR prevents iOS autocorrect from stripping formatting by capturing active meta-attributes in `shouldChangeTextInRange` and reapplying them in `didProcessEditing`

## Test Plan

Run reproduction steps from #548, the issue should be resolved.

## Screenshots / Videos


https://github.com/user-attachments/assets/dce5a5b5-0626-49bd-8fd1-1c8b34b19efc


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
