### PR TITLE
fix(iOS): `onLinkDetected` fires multiple times with partial ranges for multi-word links

### DIFF
--- a/ios/interfaces/LinkData.mm
+++ b/ios/interfaces/LinkData.mm
@@ -26,4 +26,18 @@
   return equalText && equalUrl && equalIsManual;
 }
 
+- (BOOL)isEqual:(id)other {
+  if (other == self) {
+    return YES;
+  }
+  if (![other isKindOfClass:[LinkData class]]) {
+    return NO;
+  }
+  return [self isEqualToLinkData:(LinkData *)other];
+}
+
+- (NSUInteger)hash {
+  return [self.text hash] ^ [self.url hash] ^ (self.isManual ? 1u : 0u);
+}
+
 @end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Fixes: #550 
Override `isEqual:` so runs with identical link data get merged and the full range is returned correctly.

`LinkData` was missing `isEqual:`, so `NSAttributedString` used pointer equality to compare attribute values. This kept adjacent runs of the same logical link separate, causing `getFullLinkRangeAt:` to return a partial (per-word) range and `onLinkDetected` to re-fire on every word boundary.

## Test Plan

Run reproduction steps from #550,
The issue should be resolved.

## Screenshots / Videos

https://github.com/user-attachments/assets/e78ceb5a-8165-4a6c-924f-78fb62ec69bd


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
