### PR TITLE
fix(iOS): pasting copied screenshots

### DIFF
--- a/ios/inputTextView/InputTextView.mm
+++ b/ios/inputTextView/InputTextView.mm
@@ -87,7 +87,13 @@
           [type isEqual:UTTypePNG.identifier] ||
           [type isEqual:UTTypeHEIC.identifier] ||
           [type isEqual:UTTypeTIFF.identifier]) {
-        imageData = [self getDataForImageItem:item[type] type:type];
+        id value = item[type];
+        if ([value isKindOfClass:[NSData class]]) {
+          // raw bytes available — no re-encoding needed
+          imageData = (NSData *)value;
+        } else if ([value isKindOfClass:[UIImage class]]) {
+          imageData = [self getDataForImageItem:(UIImage *)value type:type];
+        }
       } else if ([type isEqual:UTTypeWebP.identifier] ||
                  [type isEqual:UTTypeGIF.identifier]) {
         // webp and gifs: read raw bytes directly — no re-encoding needed
@@ -184,9 +190,7 @@
   }
 }
 
-- (NSData *)getDataForImageItem:(NSData *)imageData type:(NSString *)type {
-  UIImage *image = (UIImage *)imageData;
-
+- (NSData *)getDataForImageItem:(UIImage *)image type:(NSString *)type {
   if ([type isEqual:UTTypePNG.identifier]) {
     return UIImagePNGRepresentation(image);
   } else if ([type isEqual:UTTypeHEIC.identifier]) {


### PR DESCRIPTION
# Summary

Fixes pasting screenshot images on iOS. Currently it crashes the app.

## Test Plan
**IMPORTANT: Must use physical device**
- Take a screenshot
- Choose "Copy" or "Copy and Delete"
- Paste it into `EnrichedTextInput`
- Notice that image is properly pasted.
- Compare with 0.6.1 version where app is crashing in such scenario

## Screenshots / Videos

https://github.com/user-attachments/assets/dc660cd5-d583-4536-83e0-ccb56861b9e3


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
