### PR TITLE
feat(android): add copy text as rich content to EnrichedText

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/common/EnrichedConstants.kt
+++ b/android/src/main/java/com/swmansion/enriched/common/EnrichedConstants.kt
@@ -10,4 +10,5 @@ object EnrichedConstants {
   const val ORC_STRING = "\uFFFC"
 
   const val TEXT_DEFAULT_FONT_SIZE = 16f
+  const val CLIPBOARD_TAG = "react-native-enriched-clipboard"
 }

--- a/android/src/main/java/com/swmansion/enriched/text/EnrichedTextView.kt
+++ b/android/src/main/java/com/swmansion/enriched/text/EnrichedTextView.kt
@@ -1,9 +1,12 @@
 package com.swmansion.enriched.text
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.graphics.Color
 import android.graphics.text.LineBreaker
 import android.os.Build
+import android.text.Spannable
 import android.text.SpannableString
 import android.text.Spanned
 import android.text.TextUtils
@@ -129,6 +132,31 @@ class EnrichedTextView : AppCompatTextView {
   override fun performClick(): Boolean {
     super.performClick()
     return true
+  }
+
+  override fun onTextContextMenuItem(id: Int): Boolean {
+    when (id) {
+      android.R.id.copy -> {
+        handleCustomCopy()
+        return true
+      }
+    }
+    return super.onTextContextMenuItem(id)
+  }
+
+  private fun handleCustomCopy() {
+    val start = selectionStart
+    val end = selectionEnd
+    val spannable = text as Spannable
+
+    if (start < end) {
+      val selectedText = spannable.subSequence(start, end) as Spannable
+      val selectedHtml = EnrichedParser.toHtml(selectedText)
+
+      val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+      val clip = ClipData.newHtmlText(CLIPBOARD_TAG, selectedText, selectedHtml)
+      clipboard.setPrimaryClip(clip)
+    }
   }
 
   private fun updateValue() {
@@ -317,5 +345,6 @@ class EnrichedTextView : AppCompatTextView {
 
   companion object {
     private const val TAG = "EnrichedTextView"
+    private const val CLIPBOARD_TAG = "react-native-enriched-clipboard"
   }
 }

--- a/android/src/main/java/com/swmansion/enriched/text/EnrichedTextView.kt
+++ b/android/src/main/java/com/swmansion/enriched/text/EnrichedTextView.kt
@@ -154,7 +154,7 @@ class EnrichedTextView : AppCompatTextView {
       val selectedHtml = EnrichedParser.toHtml(selectedText)
 
       val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-      val clip = ClipData.newHtmlText(CLIPBOARD_TAG, selectedText, selectedHtml)
+      val clip = ClipData.newHtmlText(EnrichedConstants.CLIPBOARD_TAG, selectedText, selectedHtml)
       clipboard.setPrimaryClip(clip)
     }
   }
@@ -345,6 +345,5 @@ class EnrichedTextView : AppCompatTextView {
 
   companion object {
     private const val TAG = "EnrichedTextView"
-    private const val CLIPBOARD_TAG = "react-native-enriched-clipboard"
   }
 }

--- a/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputView.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputView.kt
@@ -9,7 +9,6 @@ import android.graphics.Color
 import android.graphics.Rect
 import android.graphics.text.LineBreaker
 import android.os.Build
-import android.text.Editable
 import android.text.InputType
 import android.text.Spannable
 import android.text.SpannableString
@@ -55,7 +54,6 @@ import com.swmansion.enriched.textinput.spans.EnrichedInputH4Span
 import com.swmansion.enriched.textinput.spans.EnrichedInputH5Span
 import com.swmansion.enriched.textinput.spans.EnrichedInputH6Span
 import com.swmansion.enriched.textinput.spans.EnrichedInputImageSpan
-import com.swmansion.enriched.textinput.spans.EnrichedInputLinkSpan
 import com.swmansion.enriched.textinput.spans.EnrichedLineHeightSpan
 import com.swmansion.enriched.textinput.spans.EnrichedSpans
 import com.swmansion.enriched.textinput.spans.interfaces.EnrichedInputSpan

--- a/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputView.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputView.kt
@@ -331,7 +331,7 @@ class EnrichedTextInputView :
       val selectedHtml = EnrichedParser.toHtml(selectedText)
 
       val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-      val clip = ClipData.newHtmlText(CLIPBOARD_TAG, selectedText, selectedHtml)
+      val clip = ClipData.newHtmlText(EnrichedConstants.CLIPBOARD_TAG, selectedText, selectedHtml)
       clipboard.setPrimaryClip(clip)
     }
   }
@@ -1089,7 +1089,6 @@ class EnrichedTextInputView :
 
   companion object {
     const val TAG = "EnrichedTextInputView"
-    const val CLIPBOARD_TAG = "react-native-enriched-clipboard"
     private const val CONTEXT_MENU_ITEM_ID = 10000
     const val DEFAULT_IME_ACTION_LABEL = "DONE"
   }


### PR DESCRIPTION
# Summary

 Add copying text as rich content to `EnrichedText`

## Test Plan

1. Add `selectable={true}` on `EnrichedText` component. 
2. Copy content from `EnrichedText`
3. Paste it inside `EnrichedTextInput`

The content pasted into `EnrichedTextInput` should be styled.

## Screenshots / Videos


https://github.com/user-attachments/assets/6f3d565e-abb9-4aae-b13f-cabe1de9901d


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
