### PR TITLE
fix(iOS): `onKeyPress` not fired for `Backspace` on empty `EnrichedTextInput`

### DIFF
--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -1798,7 +1798,7 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
 - (void)handleKeyPressInRange:(NSString *)text range:(NSRange)range {
   NSString *key = nil;
 
-  if (text.length == 0 && range.length > 0) {
+  if (text.length == 0) {
     key = @"Backspace";
   } else if ([text isEqualToString:@"\n"]) {
     key = @"Enter";


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

Closes #572 

# Summary

## Motivation

On iOS, `onKeyPress` did not fire with `"Backspace"` when the user pressed Backspace on an empty `EnrichedTextInput` (or with the cursor at position 0), breaking parity with React Native's stock `TextInput` and the Android implementation in this library. This blocks common patterns like "navigate to previous input on Backspace" in chat-style UIs.

## Solution

UIKit dispatches `textView:shouldChangeTextInRange:replacementText:` with `range=(0,0)` and `text=@""` when Backspace is pressed but there's nothing to delete. Our `handleKeyPressInRange` was filtering this case out with an over-restrictive guard:

```objc
if (text.length == 0 && range.length > 0) {
  key = @"Backspace";
}
```

The `&& range.length > 0` clause discarded the empty-backspace event. Removed it so any `text.length == 0` is treated as Backspace, which is exactly what React Native does in both its legacy bridge ([RCTEventDispatcher.mm:101](https://github.com/facebook/react-native/blob/main/packages/react-native/React/CoreModules/RCTEventDispatcher.mm)) and Fabric ([TextInputEventEmitter.cpp:116](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.cpp)) paths.

## Impact

* iOS only. One-line change in ios/EnrichedTextInputView.mm.
* No new public API, no behavioral change for any other key (Enter, Tab, regular characters, deleting selections / single chars all flow through the same path as before).
* Brings iOS to parity with Android's existing EnrichedTextInputConnectionWrapper Backspace dispatching and React Native's stock `TextInput`

## Test Plan

Provide **clear steps so another contributor can reproduce the behavior or verify the feature works**.  
For example:

There are to cases:

1. Pressing backspace on empty content
2. Pressing backspace when there is content and cursor is at the beginning

### Steps to reproduce the bug

#### Content is empty

1. Render `EnrichedTextInput` with  `onKeyPress={(e) => console.log(e.native.key}`
2. Type "A"
3. Press Backspace (you'll see the log "Backspace" and "A" will be deleted"
4. Press Backspace again (you'll see there's no log)

#### Content is not empty and cursor is at the beginning

1. Render `EnrichedTextInput` with  `onKeyPress={(e) => console.log(e.native.key}`
2. Type "A"
3. Place the cursor at the beginning
4. Press Backspace (you'll see there's no log)

### Stepts to verify

#### Content is empty

1. Render `EnrichedTextInput` with  `onKeyPress={(e) => console.log(e.native.key}`
2. Type "A"
3. Press Backspace (you'll see the log "Backspace" and "A" will be deleted"
4. Press Backspace again (you'll see the log "Backspace")

#### Content is not empty and cursor is at the beginning

1. Render `EnrichedTextInput` with  `onKeyPress={(e) => console.log(e.native.key}`
2. Type "A"
3. Place the cursor at the beginning
4. Press Backspace (you'll see the log "Backspace")

## Screenshots / Videos

### Bug reproduction

https://github.com/user-attachments/assets/3b9a84b2-d835-448e-a191-eca7d83544ab

### Fix verification

https://github.com/user-attachments/assets/9ddccb3e-ecfb-401a-80d4-5f80cea0b059

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)
