### PR TITLE
fix(iOS): typo on UIKit imports

### DIFF
--- a/ios/inputTextView/InputTextView.h
+++ b/ios/inputTextView/InputTextView.h
@@ -1,5 +1,5 @@
 #pragma once
-#import <UIkit/UIKit.h>
+#import <UIKit/UIKit.h>
 
 @interface InputTextView : UITextView
 @property(nonatomic, weak) id input;

--- a/ios/interfaces/StylePair.h
+++ b/ios/interfaces/StylePair.h
@@ -1,5 +1,5 @@
 #pragma once
-#import <UIkit/UIKit.h>
+#import <UIKit/UIKit.h>
 
 @interface StylePair : NSObject
 


### PR DESCRIPTION
# Summary
Fixes: #577 
Fixes a case-sensitivity bug in `StylePair.h` and `InputTextView.h` where `UIkit` was used instead of `UIKit`. Solves #577 .

- Fixes: #
- `UIkit/UIKit.h` is an incorrect import path — the correct framework name is `UIKit` (capital K). macOS case-insensitive filesystems silently accept the typo, but case-sensitive environments (CI, certain Xcode configs) fail with `'UIkit/UIKit.h' file not found`.
- Changed the single import lines in `ios/interfaces/StylePair.h` and `ios/inputTextView/InputTextView.h`.
- Impacts: iOS native layer only.

## Test Plan

1. Install the library in a React Native / Expo project
2. Run `npx expo prebuild` (Expo managed workflow)
3. Build the iOS target: `npx expo run:ios`
4. **Expected:** builds successfully
5. **Before fix:** compilation fails with `'UIkit/UIKit.h' file not found`.

## Screenshots / Videos

**Before**
```
❌ (/node_modules/react-native-enriched/ios/interfaces/StylePair.h:2:9) // also for ios/inputTextView/InputTextView.h
 > 2 | #import <UIkit/UIKit.h>
     |         ^ 'UIkit/UIKit.h' file not found
```

**After:** build completes without errors.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |      ✅      |
| Android |     N/A      |

## Checklist

- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)