### PR TITLE
fix(android): parsing empty lines to html

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/common/parser/EnrichedParser.java
+++ b/android/src/main/java/com/swmansion/enriched/common/parser/EnrichedParser.java
@@ -80,11 +80,16 @@ public class EnrichedParser {
     StringBuilder out = new StringBuilder();
     withinHtml(out, text);
     String outString = out.toString();
+
     // Codeblocks and blockquotes appends a newline character by default, so we have to remove it
     String normalizedCodeBlock = outString.replaceAll("</codeblock>\\n<br>", "</codeblock>");
     String normalizedBlockQuote =
         normalizedCodeBlock.replaceAll("</blockquote>\\n<br>", "</blockquote>");
-    return "<html>\n" + normalizedBlockQuote + "</html>";
+
+    // replace empty <p></p> into <br> in the very end
+    String normalizedHtml = normalizedBlockQuote.replaceAll("<p></p>", "<br>");
+
+    return "<html>\n" + normalizedHtml + "</html>";
   }
 
   public static String toHtmlWithDefault(CharSequence text) {


### PR DESCRIPTION
# Summary

Fixes: #545

Replace `<p></p>` into `<br>` when parsing input content into HTML.

## Test Plan

Run reproduction steps from #545 
The issue should be be resolved

## Screenshots / Videos

<img width="361" height="764" alt="image" src="https://github.com/user-attachments/assets/10d4ff6a-0fa2-4e27-aab2-767e98dc3ee2" />

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
