### PR TITLE
fix(web): fixed onKeyPress not being called with Enter and Backspace

### DIFF
--- a/src/web/EnrichedTextInput.tsx
+++ b/src/web/EnrichedTextInput.tsx
@@ -149,7 +149,7 @@ export const EnrichedTextInput = ({
         onChangeSelection?.(adaptWebToNativeEvent(null, { start, end, text }));
       },
       editorProps: {
-        handleKeyPress: (_, event) => {
+        handleKeyDown: (_, event) => {
           onKeyPress?.(adaptWebToNativeEvent(event, { key: event.key }));
           return false;
         },


### PR DESCRIPTION

# Summary

+ `handleKeyPress` in tiptap does not report Enter, Backspace keys which are required by the native version
+  switched from `handleKeyPress` to `handleKeyDown` which does report 

## Test Plan

+ Launch example app
+ Filter the console by `[EnrichedTextInput] onKeyPress` check if for Enter and Backspace logs appear

## Screenshots / Videos

Before:

https://github.com/user-attachments/assets/3b70c02f-e2e7-402c-bdc3-edc1b54bc7e0

After:

https://github.com/user-attachments/assets/3783ec8b-3d4f-4cc6-adbc-d84d0df23c05


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |
| Web |    ✅     |


## Checklist

- [x] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
