### PR TITLE
fix(web): fixed setLink and positionMapping

### DIFF
--- a/.playwright/tests/testLinks.spec.ts
+++ b/.playwright/tests/testLinks.spec.ts
@@ -163,6 +163,56 @@ test.describe('test-links setLink table', () => {
       url: 'https://clamp.setlink',
       expectContains: '<p><a href="https://clamp.setlink">Z</a></p>',
     },
+    {
+      name: 'wraps bold italic list item text with link',
+      html: '<html><ul><li><b><i>styled</i></b></li><li>hello</li></ul></html>',
+      start: '0',
+      end: '6',
+      text: 'styled',
+      url: 'https://list-styled.example',
+      expectContains:
+        '<ul><li><a href="https://list-styled.example"><b><i>styled</i></b></a></li><li>hello</li></ul>',
+    },
+    {
+      name: 'inserts linked text at cursor at very start of first list item',
+      html: '<html><ul><li>first</li><li>second</li></ul></html>',
+      start: '0',
+      end: '0',
+      text: 'Link',
+      url: 'https://cursor-list.example',
+      expectContains:
+        '<ul><li><a href="https://cursor-list.example">Link</a>first</li><li>second</li></ul>',
+    },
+    {
+      name: 'inserts linked text at cursor inside empty list item',
+      html: '<html><ul><li></li></ul></html>',
+      start: '0',
+      end: '0',
+      text: 'Link',
+      url: 'https://empty-list.example',
+      expectContains:
+        '<ul><li><a href="https://empty-list.example">Link</a></li></ul>',
+    },
+    {
+      name: 'wraps mixed bold and bold-italic text in list item with link as outermost mark',
+      html: '<html><ul><li><b>ab<i>cd</i></b></li></ul></html>',
+      start: '0',
+      end: '4',
+      text: 'abcd',
+      url: 'https://mixed-marks.example',
+      expectContains:
+        '<ul><li><a href="https://mixed-marks.example"><b>ab<i>cd</i></b></a></li></ul>',
+    },
+    {
+      name: 'setLink replacement longer than selection applies marks from range start only',
+      html: '<html><ul><li><b>ab<i>cd</i></b></li></ul></html>',
+      start: '0',
+      end: '4',
+      text: 'abcdef',
+      url: 'https://mixed-marks-longer.example',
+      expectContains:
+        '<ul><li><a href="https://mixed-marks-longer.example"><b>abcdef</b></a></li></ul>',
+    },
   ];
 
   for (const c of cases) {

--- a/src/web/formats/EnrichedLink.ts
+++ b/src/web/formats/EnrichedLink.ts
@@ -102,10 +102,21 @@ export function setLink(
     .chain()
     .focus()
     .command(({ tr, state: s }) => {
-      const marksAtRangeStart = doc.resolve(from).marks();
-      const marksWithLink = linkMark.addToSet(marksAtRangeStart);
-      tr.delete(from, to);
-      tr.insert(from, s.schema.text(text, marksWithLink));
+      if (from === to) {
+        const marksAtRangeStart = doc.resolve(from).marks();
+        const marksWithLink = linkMark.addToSet(marksAtRangeStart);
+        tr.insert(from, s.schema.text(text, marksWithLink));
+      } else {
+        const currentText = doc.textBetween(from, to);
+
+        if (text !== currentText) {
+          const marksAtRangeStart = doc.resolve(from).marks();
+          const marksWithLink = linkMark.addToSet(marksAtRangeStart);
+          tr.replaceWith(from, to, s.schema.text(text, marksWithLink));
+        } else {
+          tr.addMark(from, to, linkMark);
+        }
+      }
       return true;
     })
     .run();

--- a/src/web/positionMapping.ts
+++ b/src/web/positionMapping.ts
@@ -30,37 +30,38 @@ export function tiptapPosToNativePos(doc: Node, tiptapPos: number): number {
 /**
  * Returns the TipTap document position for a given native position.
  *
- * Equivalent mental model: build an array `nativeByTiptapPos` where
- * `nativeByTiptapPos[tiptapPos] = tiptapPosToNativePos(doc, tiptapPos)`.
- * This function finds the first index where
- * `nativeByTiptapPos[index] >= nativePos`, but does it with binary search
- * instead of creating the whole array.
- *
- * We want the leftmost TipTap position T where tiptapPosToNativePos(T) >= nativePos.
- * Leftmost matters because gap positions (for example TipTap 5 and 6 for native 4)
- * share the same native value. We choose the earlier position.
+ * Traverses only text-bearing block nodes (paragraphs, headings, etc.),
+ * skipping wrapper nodes like block quotes and lists. This ensures the result
+ * is always a valid cursor position drilled down to the innermost content node.
  */
 export function nativePosToTiptapPos(doc: Node, nativePos: number): number {
-  if (nativePos <= 0) return 1;
+  let currentNativePos = 0;
+  let targetTiptapPos = -1;
+  let lastValidTiptapPos = -1;
 
-  const maxPos = doc.content.size;
-  const totalNativeLen = doc.textBetween(0, maxPos, '\n').length;
+  doc.descendants((node, pos) => {
+    if (targetTiptapPos !== -1) return false;
 
-  if (nativePos >= totalNativeLen) {
-    return maxPos - 1; // clamp to end of last block's content
-  }
+    // Only consider text-bearing leaf blocks (paragraphs, headings, code blocks).
+    // Wrapper nodes (lists, list items, block quotes) are skipped
+    if (node.isTextblock) {
+      const textLen = node.textContent.length;
 
-  let low = 0;
-  let high = maxPos;
-  let result = maxPos - 1;
-  while (low <= high) {
-    const mid = low + Math.floor((high - low) / 2);
-    if (tiptapPosToNativePos(doc, mid) >= nativePos) {
-      result = mid; // mid is a valid candidate; try to find an earlier one
-      high = mid - 1;
-    } else {
-      low = mid + 1; // mid is too small, search right
+      if (currentNativePos + textLen >= nativePos) {
+        // pos is before the opening tag; pos+1 is the first position inside.
+        const offset = Math.max(0, nativePos - currentNativePos);
+        targetTiptapPos = pos + 1 + offset;
+        return false;
+      }
+
+      currentNativePos += textLen + 1; // +1 for the '\n' block separator
+      lastValidTiptapPos = pos + 1 + textLen;
     }
-  }
-  return result;
+
+    return true;
+  });
+
+  if (targetTiptapPos !== -1) return targetTiptapPos;
+  if (lastValidTiptapPos !== -1) return lastValidTiptapPos;
+  return 1;
 }


### PR DESCRIPTION

# Summary

+ fixes small bugs related to setLink: creation of new list items when they shouldn't have been created, not preserving all the styles when possible
+ partially the bugs originate from the `setLink` function itself i.e. previously it was lacking special handling for the case when `text == currentText` where we can preserve all the styles, issues with lists were related to `positionMapping.ts`.   The old `nativePosToTiptapPos` used binary search probing via tiptapPosToNativePos, which worked for top-level `<p>` tags but returned wrong positions for content inside wrapper nodes (lists, blockquotes, code blocks); the probe would land on wrapper-node boundaries  instead of actual text positions. Replaced with a traversing using `doc.descendants()` that only visits `isTextblock` leaf nodes, counting up native offsets as it goes

## Test Plan

- Run `yarn test:e2e:web` to verify new e2e tests pass
- Run example web app and play around with creating links 

## Screenshots / Videos

Before:

https://github.com/user-attachments/assets/d04efcef-402d-4ea8-af9b-8580f9e8589c

After:


https://github.com/user-attachments/assets/1475a06f-0dcc-4792-9936-d28e9b03bbb5



## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |
| Web |    ✅     |


## Checklist

- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)
