### PR TITLE
feat(web): add styles for mentions

### DIFF
--- a/apps/example-web/src/defaultHtmlStyle.ts
+++ b/apps/example-web/src/defaultHtmlStyle.ts
@@ -62,4 +62,16 @@ export const WEB_DEFAULT_HTML_STYLE: HtmlStyle = {
     marginLeft: 24,
     boxColor: 'rgb(0, 26, 114)',
   },
+  mention: {
+    '@': {
+      backgroundColor: 'lightgreen',
+      color: 'green',
+      textDecorationLine: 'none',
+    },
+    '#': {
+      backgroundColor: 'lightblue',
+      color: 'blue',
+      textDecorationLine: 'underline',
+    },
+  },
 };

--- a/src/utils/expandMentionStylesForIndicators.ts
+++ b/src/utils/expandMentionStylesForIndicators.ts
@@ -1,0 +1,19 @@
+import type { HtmlStyle, MentionStyleProperties } from '../types';
+import { DEFAULT_HTML_STYLE } from './defaultHtmlStyle';
+import { isMentionStyleRecord } from './isMentionStyleRecord';
+
+export function expandMentionStylesForIndicators(
+  mention: HtmlStyle['mention'] | undefined,
+  indicators: string[]
+): Record<string, MentionStyleProperties> {
+  const out: Record<string, MentionStyleProperties> = {};
+  for (const indicator of indicators) {
+    out[indicator] = {
+      ...DEFAULT_HTML_STYLE.mention,
+      ...(isMentionStyleRecord(mention)
+        ? (mention[indicator] ?? mention.default ?? {})
+        : mention),
+    };
+  }
+  return out;
+}

--- a/src/utils/isMentionStyleRecord.ts
+++ b/src/utils/isMentionStyleRecord.ts
@@ -1,0 +1,22 @@
+import type { HtmlStyle, MentionStyleProperties } from '../types';
+
+export function isMentionStyleRecord(
+  mentionStyle: HtmlStyle['mention']
+): mentionStyle is Record<string, MentionStyleProperties> {
+  if (
+    mentionStyle &&
+    typeof mentionStyle === 'object' &&
+    !Array.isArray(mentionStyle)
+  ) {
+    const keys = Object.keys(mentionStyle);
+    return (
+      keys.length > 0 &&
+      keys.every(
+        (key) =>
+          typeof (mentionStyle as Record<string, unknown>)[key] === 'object' &&
+          (mentionStyle as Record<string, unknown>)[key] !== null
+      )
+    );
+  }
+  return false;
+}

--- a/src/utils/normalizeHtmlStyle.ts
+++ b/src/utils/normalizeHtmlStyle.ts
@@ -6,34 +6,13 @@ import type {
   MentionStyleProperties,
 } from '../types';
 import type { EnrichedTextHtmlStyleInternal } from '../spec/EnrichedTextNativeComponent';
-
-const MENTION_DEFAULT_KEY = '_default';
 import {
   DEFAULT_HTML_STYLE,
   DEFAULT_ENRICHED_TEXT_STYLE,
 } from './defaultHtmlStyle';
+import { expandMentionStylesForIndicators } from './expandMentionStylesForIndicators';
 
-const isMentionStyleRecord = (
-  mentionStyle: HtmlStyle['mention']
-): mentionStyle is Record<string, MentionStyleProperties> => {
-  if (
-    mentionStyle &&
-    typeof mentionStyle === 'object' &&
-    !Array.isArray(mentionStyle)
-  ) {
-    const keys = Object.keys(mentionStyle);
-
-    return (
-      keys.length > 0 &&
-      keys.every(
-        (key) =>
-          typeof (mentionStyle as Record<string, unknown>)[key] === 'object' &&
-          (mentionStyle as Record<string, unknown>)[key] !== null
-      )
-    );
-  }
-  return false;
-};
+const MENTION_DEFAULT_KEY = '_default';
 
 const parseOlStyles = (style: HtmlStyle) => {
   let markerFontWeight: string | undefined;
@@ -55,16 +34,10 @@ const convertToHtmlStyleInternal = (
   style: HtmlStyle,
   mentionIndicators: string[]
 ): HtmlStyleInternal => {
-  const mentionStyles: Record<string, MentionStyleProperties> = {};
-
-  mentionIndicators.forEach((indicator) => {
-    mentionStyles[indicator] = {
-      ...DEFAULT_HTML_STYLE.mention,
-      ...(isMentionStyleRecord(style.mention)
-        ? (style.mention[indicator] ?? style.mention.default ?? {})
-        : style.mention),
-    };
-  });
+  const mentionStyles = expandMentionStylesForIndicators(
+    style.mention,
+    mentionIndicators
+  );
 
   let markerFontWeight: string | undefined;
   if (style.ol?.markerFontWeight) {

--- a/src/web/EnrichedTextInput.css
+++ b/src/web/EnrichedTextInput.css
@@ -60,13 +60,6 @@
   text-decoration-line: var(--eti-link-text-decoration-line);
 }
 
-/* TODO: Remove this once we handle htmlStyle for mentions  */
-.eti-editor mention {
-  color: #14532d;
-  background-color: #dcfce7;
-  text-decoration-line: none;
-}
-
 .eti-editor ul:not([data-type]) {
   margin: 0;
   list-style: none;

--- a/src/web/EnrichedTextInput.tsx
+++ b/src/web/EnrichedTextInput.tsx
@@ -36,6 +36,7 @@ import {
 } from './tiptapHtmlNormalizer';
 import { ENRICHED_TEXT_INPUT_DEFAULT_PROPS } from '../utils/EnrichedTextInputDefaultProps';
 import { enrichedInputStyleToCSSProperties } from './styleConversion/enrichedInputStyleToCSSProperties';
+import { buildMentionRulesCSS } from './styleConversion/buildMentionRulesCSS';
 import {
   htmlStyleToCSSVariables,
   mergeWithDefaultHtmlStyle,
@@ -299,17 +300,25 @@ export const EnrichedTextInput = ({
     [resolvedHtmlStyle]
   );
 
+  const mentionRulesCSS = useMemo(
+    () => buildMentionRulesCSS(resolvedHtmlStyle),
+    [resolvedHtmlStyle]
+  );
+
   const finalStyle = useMemo(
     () => ({ ...editorStyle, ...cssVars }),
     [editorStyle, cssVars]
   );
 
   return (
-    <EditorContent
-      editor={editor}
-      className="eti-editor"
-      style={finalStyle}
-      data-placeholder={placeholder}
-    />
+    <>
+      {mentionRulesCSS ? <style>{mentionRulesCSS}</style> : null}
+      <EditorContent
+        editor={editor}
+        className="eti-editor"
+        style={finalStyle}
+        data-placeholder={placeholder}
+      />
+    </>
   );
 };

--- a/src/web/styleConversion/__tests__/buildMentionRulesCSS.test.ts
+++ b/src/web/styleConversion/__tests__/buildMentionRulesCSS.test.ts
@@ -1,0 +1,30 @@
+import { mergeWithDefaultHtmlStyle } from '../htmlStyleToCSSVariables';
+import { buildMentionRulesCSS } from '../buildMentionRulesCSS';
+
+describe('buildMentionRulesCSS', () => {
+  it('emits default class rule and attribute rule for @', () => {
+    const merged = mergeWithDefaultHtmlStyle({
+      mention: { '@': { color: 'red' } },
+    });
+    const css = buildMentionRulesCSS(merged);
+
+    expect(css).toMatch(/\.eti-editor mention\s*\{/);
+    expect(css).toContain('var(--eti-mention-default-color)');
+    expect(css).toContain('var(--eti-mention-default-background-color)');
+    expect(css).toContain('var(--eti-mention-default-text-decoration-line)');
+
+    expect(css).toContain('.eti-editor mention[indicator="@"]');
+    expect(css).toContain('var(--eti-mention-u0040-color)');
+    expect(css).toContain('var(--eti-mention-u0040-background-color)');
+    expect(css).toContain('var(--eti-mention-u0040-text-decoration-line)');
+  });
+
+  it('returns empty string when mention is missing', () => {
+    expect(buildMentionRulesCSS(undefined)).toBe('');
+    expect(buildMentionRulesCSS({})).toBe('');
+  });
+
+  it('returns empty string when mention is not a style record', () => {
+    expect(buildMentionRulesCSS({ mention: { color: 'red' } })).toBe('');
+  });
+});

--- a/src/web/styleConversion/__tests__/htmlStyleToCSSVariables.test.ts
+++ b/src/web/styleConversion/__tests__/htmlStyleToCSSVariables.test.ts
@@ -1,5 +1,5 @@
 import type { CSSProperties } from 'react';
-import type { HtmlStyle } from '../../../types';
+import type { HtmlStyle, MentionStyleProperties } from '../../../types';
 import { DEFAULT_HTML_STYLE } from '../../../utils/defaultHtmlStyle';
 import {
   htmlStyleToCSSVariables,
@@ -8,13 +8,66 @@ import {
 
 type CodeStyle = HtmlStyle['code'];
 
+const DEFAULT_MENTION_CSS_VARS: Record<string, string> = {
+  '--eti-mention-default-color': String(DEFAULT_HTML_STYLE.mention.color),
+  '--eti-mention-default-background-color': String(
+    DEFAULT_HTML_STYLE.mention.backgroundColor
+  ),
+  '--eti-mention-default-text-decoration-line': String(
+    DEFAULT_HTML_STYLE.mention.textDecorationLine
+  ),
+};
+
+const defaultMentionOnlyResolved = {
+  default: { ...DEFAULT_HTML_STYLE.mention },
+};
+
 describe('mergeWithDefaultHtmlStyle', () => {
-  const cases: Array<[HtmlStyle | undefined, Partial<Required<HtmlStyle>>]> = [
-    [undefined, DEFAULT_HTML_STYLE],
-    [{}, DEFAULT_HTML_STYLE],
+  it('undefined → default mention key', () => {
+    expect(mergeWithDefaultHtmlStyle(undefined)).toMatchObject({
+      ...DEFAULT_HTML_STYLE,
+      mention: defaultMentionOnlyResolved,
+    });
+  });
+
+  it('{} → default mention key', () => {
+    expect(mergeWithDefaultHtmlStyle({})).toMatchObject({
+      ...DEFAULT_HTML_STYLE,
+      mention: defaultMentionOnlyResolved,
+    });
+  });
+
+  it('flat mention → default key only', () => {
+    expect(
+      mergeWithDefaultHtmlStyle({ mention: { color: 'purple' } }).mention
+    ).toEqual({
+      default: { ...DEFAULT_HTML_STYLE.mention, color: 'purple' },
+    });
+  });
+
+  it('mention: default key + @', () => {
+    const m = mergeWithDefaultHtmlStyle({
+      mention: {
+        'default': { backgroundColor: 'white' },
+        '@': { color: 'red' },
+      },
+    }).mention as Record<string, MentionStyleProperties>;
+    expect(m.default).toMatchObject({
+      ...DEFAULT_HTML_STYLE.mention,
+      backgroundColor: 'white',
+    });
+    expect(m['@']).toMatchObject({
+      ...DEFAULT_HTML_STYLE.mention,
+      color: 'red',
+      backgroundColor: DEFAULT_HTML_STYLE.mention.backgroundColor,
+    });
+  });
+
+  const cases: Array<[HtmlStyle, Partial<Required<HtmlStyle>>]> = [
     [
       { code: { color: 'purple' } },
       {
+        mention: defaultMentionOnlyResolved,
         code: {
           color: 'purple',
           backgroundColor: DEFAULT_HTML_STYLE.code.backgroundColor,
@@ -23,15 +76,22 @@ describe('mergeWithDefaultHtmlStyle', () => {
     ],
     [
       { code: { color: 'purple', backgroundColor: 'white' } },
-      { code: { color: 'purple', backgroundColor: 'white' } },
+      {
+        mention: defaultMentionOnlyResolved,
+        code: { color: 'purple', backgroundColor: 'white' },
+      },
     ],
     [
       { h1: { fontSize: 48 } },
-      { h1: { fontSize: 48, bold: DEFAULT_HTML_STYLE.h1.bold } },
+      {
+        mention: defaultMentionOnlyResolved,
+        h1: { fontSize: 48, bold: DEFAULT_HTML_STYLE.h1.bold },
+      },
     ],
     [
       { ul: { bulletColor: 'red' } },
       {
+        mention: defaultMentionOnlyResolved,
         ul: {
           bulletColor: 'red',
           bulletSize: DEFAULT_HTML_STYLE.ul.bulletSize,
@@ -48,19 +108,23 @@ describe('mergeWithDefaultHtmlStyle', () => {
 });
 
 describe('htmlStyleToCSSVariables', () => {
-  it('returns empty object for undefined input', () => {
-    expect(htmlStyleToCSSVariables(undefined)).toEqual({});
+  it('undefined → default mention vars only', () => {
+    expect(htmlStyleToCSSVariables(undefined)).toEqual(
+      DEFAULT_MENTION_CSS_VARS as CSSProperties
+    );
   });
 
-  it('returns empty object for empty style', () => {
-    expect(htmlStyleToCSSVariables({})).toEqual({});
+  it('empty style → default mention vars only', () => {
+    expect(htmlStyleToCSSVariables({})).toEqual(
+      DEFAULT_MENTION_CSS_VARS as CSSProperties
+    );
   });
 
   it('integer color → rgba string', () => {
     const input = { code: { color: 0xff0000ff as unknown as string } };
-    expect(htmlStyleToCSSVariables(input)).toEqual({
+    expect(htmlStyleToCSSVariables(input)).toMatchObject({
       '--eti-code-color': 'rgba(255, 0, 0, 1)',
-    } as CSSProperties);
+    });
   });
 
   describe('code styles', () => {
@@ -77,10 +141,10 @@ describe('htmlStyleToCSSVariables', () => {
       ],
       [{}, {}],
       [undefined, {}],
-    ] as Array<[CodeStyle, CSSProperties]>;
+    ] as Array<[CodeStyle, Record<string, string>]>;
 
     it.each(cases)('%j → %j', (code, expected) => {
-      expect(htmlStyleToCSSVariables({ code })).toEqual(expected);
+      expect(htmlStyleToCSSVariables({ code })).toMatchObject(expected);
     });
   });
 
@@ -105,7 +169,7 @@ describe('htmlStyleToCSSVariables', () => {
     ] as Array<[HtmlStyle, CSSProperties]>;
 
     it.each(cases)('%j → %j', (input, expected) => {
-      expect(htmlStyleToCSSVariables(input)).toEqual(expected);
+      expect(htmlStyleToCSSVariables(input)).toMatchObject(expected);
     });
   });
 
@@ -119,12 +183,12 @@ describe('htmlStyleToCSSVariables', () => {
           color: '#444',
         },
       })
-    ).toEqual({
+    ).toMatchObject({
       '--eti-blockquote-border-color': '#ccc',
       '--eti-blockquote-border-width': '3px',
       '--eti-blockquote-gap-width': '12px',
       '--eti-blockquote-color': '#444',
-    } as CSSProperties);
+    });
   });
 
   it('maps codeblock styles to CSS variables', () => {
@@ -136,11 +200,11 @@ describe('htmlStyleToCSSVariables', () => {
           borderRadius: 8,
         },
       })
-    ).toEqual({
+    ).toMatchObject({
       '--eti-codeblock-bg-color': '#1e1e1e',
       '--eti-codeblock-color': '#d4d4d4',
       '--eti-codeblock-border-radius': '8px',
-    } as CSSProperties);
+    });
   });
 
   it('maps anchor link styles to CSS variables', () => {
@@ -148,10 +212,10 @@ describe('htmlStyleToCSSVariables', () => {
       htmlStyleToCSSVariables({
         a: { color: 'blue', textDecorationLine: 'underline' },
       })
-    ).toEqual({
+    ).toMatchObject({
       '--eti-link-color': 'blue',
       '--eti-link-text-decoration-line': 'underline',
-    } as CSSProperties);
+    });
   });
 
   it('maps ul styles to CSS variables', () => {
@@ -164,12 +228,12 @@ describe('htmlStyleToCSSVariables', () => {
           gapWidth: 4,
         },
       })
-    ).toEqual({
+    ).toMatchObject({
       '--eti-ul-bullet-color': '#ff0000',
       '--eti-ul-bullet-size': '12px',
       '--eti-ul-margin-left': '8px',
       '--eti-ul-gap-width': '4px',
-    } as CSSProperties);
+    });
   });
 
   it('maps ol styles to CSS variables', () => {
@@ -182,12 +246,12 @@ describe('htmlStyleToCSSVariables', () => {
           markerColor: '#00ff00',
         },
       })
-    ).toEqual({
+    ).toMatchObject({
       '--eti-ol-gap-width': '6px',
       '--eti-ol-margin-left': '10px',
       '--eti-ol-marker-font-weight': '700',
       '--eti-ol-marker-color': '#00ff00',
-    } as CSSProperties);
+    });
   });
 
   it('maps ulCheckbox styles to CSS variables', () => {
@@ -200,11 +264,41 @@ describe('htmlStyleToCSSVariables', () => {
           boxColor: '#336699',
         },
       })
-    ).toEqual({
+    ).toMatchObject({
       '--eti-checkbox-box-size': '20px',
       '--eti-checkbox-gap-width': '8px',
       '--eti-checkbox-margin-left': '12px',
       '--eti-checkbox-box-color': '#336699',
-    } as CSSProperties);
+    });
+  });
+});
+
+describe('mention CSS variables', () => {
+  it('flat mention → default vars', () => {
+    const vars = htmlStyleToCSSVariables({
+      mention: { color: '#f00' },
+    }) as Record<string, string>;
+    expect(vars['--eti-mention-default-color']).toBe('#f00');
+  });
+
+  it('mention @ + default vars', () => {
+    const merged = mergeWithDefaultHtmlStyle({
+      mention: { '@': { color: '#ff0000' } },
+    });
+    const vars = htmlStyleToCSSVariables(merged) as Record<string, string>;
+    expect(vars['--eti-mention-u0040-color']).toBe('#ff0000');
+    expect(vars['--eti-mention-default-color']).toBe(
+      DEFAULT_HTML_STYLE.mention.color
+    );
+  });
+
+  it('mention {} → default vars', () => {
+    const vars = htmlStyleToCSSVariables({ mention: {} }) as Record<
+      string,
+      string
+    >;
+    expect(vars['--eti-mention-default-color']).toBe(
+      DEFAULT_HTML_STYLE.mention.color
+    );
   });
 });

--- a/src/web/styleConversion/__tests__/mentionIndicatorCssKey.test.ts
+++ b/src/web/styleConversion/__tests__/mentionIndicatorCssKey.test.ts
@@ -1,0 +1,22 @@
+import {
+  indicatorToMentionCssKey,
+  MENTION_STYLE_DEFAULT_KEY,
+} from '../mentionIndicatorCssKey';
+
+describe('indicatorToMentionCssKey', () => {
+  it('maps default style key to default CSS key segment', () => {
+    expect(indicatorToMentionCssKey(MENTION_STYLE_DEFAULT_KEY)).toBe('default');
+  });
+
+  it('encodes @ as Unicode code point', () => {
+    expect(indicatorToMentionCssKey('@')).toBe('u0040');
+  });
+
+  it('encodes # as Unicode code point', () => {
+    expect(indicatorToMentionCssKey('#')).toBe('u0023');
+  });
+
+  it('encodes empty string as u0000', () => {
+    expect(indicatorToMentionCssKey('')).toBe('u0000');
+  });
+});

--- a/src/web/styleConversion/buildMentionRulesCSS.ts
+++ b/src/web/styleConversion/buildMentionRulesCSS.ts
@@ -1,0 +1,42 @@
+import type { HtmlStyle, MentionStyleProperties } from '../../types';
+import { isMentionStyleRecord } from '../../utils/isMentionStyleRecord';
+import { ETI_MENTION_CSS_VARS } from './htmlStyleToCSSVariables';
+import { MENTION_STYLE_DEFAULT_KEY } from './mentionIndicatorCssKey';
+
+function escapeIndicatorForCssAttributeSelector(indicator: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(indicator);
+  }
+  return indicator.replace(/["\\]/g, '\\$&');
+}
+
+export function buildMentionRulesCSS(htmlStyle?: HtmlStyle): string {
+  const mapRaw = htmlStyle?.mention;
+  if (!mapRaw || typeof mapRaw !== 'object' || !isMentionStyleRecord(mapRaw)) {
+    return '';
+  }
+
+  const map: Record<string, MentionStyleProperties> = mapRaw;
+  const keys = Object.keys(map);
+  if (keys.length === 0) {
+    return '';
+  }
+
+  const lines: string[] = [];
+  for (const indicator of keys) {
+    const selector =
+      indicator === MENTION_STYLE_DEFAULT_KEY
+        ? '.eti-editor mention'
+        : `.eti-editor mention[indicator="${escapeIndicatorForCssAttributeSelector(indicator)}"]`;
+
+    lines.push(
+      `${selector} {
+  color: var(${ETI_MENTION_CSS_VARS.color(indicator)});
+  background-color: var(${ETI_MENTION_CSS_VARS.backgroundColor(indicator)});
+  text-decoration-line: var(${ETI_MENTION_CSS_VARS.textDecorationLine(indicator)});
+}`.trim()
+    );
+  }
+
+  return lines.join('\n');
+}

--- a/src/web/styleConversion/htmlStyleToCSSVariables.ts
+++ b/src/web/styleConversion/htmlStyleToCSSVariables.ts
@@ -1,19 +1,37 @@
 import type { CSSProperties } from 'react';
 import type { ColorValue } from 'react-native';
-import type { HtmlStyle } from '../../types';
+import type { HtmlStyle, MentionStyleProperties } from '../../types';
 import { DEFAULT_HTML_STYLE } from '../../utils/defaultHtmlStyle';
+import { expandMentionStylesForIndicators } from '../../utils/expandMentionStylesForIndicators';
 import { HEADING_TAGS } from '../formats/EnrichedHeading';
+import {
+  indicatorToMentionCssKey,
+  MENTION_STYLE_DEFAULT_KEY,
+} from './mentionIndicatorCssKey';
 import { toColor } from './toColor';
+import { isMentionStyleRecord } from '../../utils/isMentionStyleRecord';
 
 export function mergeWithDefaultHtmlStyle(
   htmlStyle?: HtmlStyle
 ): Required<HtmlStyle> {
-  const merged: Record<string, any> = { ...DEFAULT_HTML_STYLE };
+  const style = htmlStyle ?? {};
 
-  for (const key in htmlStyle) {
+  const mentionMap = expandMentionStylesForIndicatorsIncludeDefault(style);
+  const converted: HtmlStyle = {
+    ...style,
+    mention: mentionMap,
+  };
+
+  const merged: Record<string, unknown> = { ...DEFAULT_HTML_STYLE };
+
+  for (const key in converted) {
+    if (key === 'mention') {
+      merged[key] = { ...(converted.mention as object) };
+      continue;
+    }
     merged[key] = {
       ...DEFAULT_HTML_STYLE[key as keyof HtmlStyle],
-      ...(htmlStyle[key as keyof HtmlStyle] as object),
+      ...(converted[key as keyof HtmlStyle] as object),
     };
   }
 
@@ -44,6 +62,15 @@ const ETI_CSS_VARS = {
   checkboxGapWidth: '--eti-checkbox-gap-width',
   checkboxMarginLeft: '--eti-checkbox-margin-left',
   checkboxBoxColor: '--eti-checkbox-box-color',
+} as const;
+
+export const ETI_MENTION_CSS_VARS = {
+  color: (indicator: string) =>
+    `--eti-mention-${indicatorToMentionCssKey(indicator)}-color`,
+  backgroundColor: (indicator: string) =>
+    `--eti-mention-${indicatorToMentionCssKey(indicator)}-background-color`,
+  textDecorationLine: (indicator: string) =>
+    `--eti-mention-${indicatorToMentionCssKey(indicator)}-text-decoration-line`,
 } as const;
 
 function setColorVar(
@@ -145,6 +172,42 @@ function applyCheckboxListVars(
   setColorVar(vars, ETI_CSS_VARS.checkboxBoxColor, ulCheckbox?.boxColor);
 }
 
+function applyMentionVars(
+  vars: Record<string, string>,
+  mention: Record<string, MentionStyleProperties>
+): void {
+  for (const [indicator, mentionStyle] of Object.entries(mention)) {
+    setColorVar(
+      vars,
+      ETI_MENTION_CSS_VARS.color(indicator),
+      mentionStyle.color
+    );
+    setColorVar(
+      vars,
+      ETI_MENTION_CSS_VARS.backgroundColor(indicator),
+      mentionStyle.backgroundColor
+    );
+    if (mentionStyle.textDecorationLine != null) {
+      vars[ETI_MENTION_CSS_VARS.textDecorationLine(indicator)] =
+        mentionStyle.textDecorationLine;
+    }
+  }
+}
+
+function expandMentionStylesForIndicatorsIncludeDefault(htmlStyle?: HtmlStyle) {
+  const mentionIndicators = isMentionStyleRecord(htmlStyle?.mention)
+    ? Object.keys(htmlStyle?.mention)
+    : [];
+
+  if (!mentionIndicators.includes(MENTION_STYLE_DEFAULT_KEY))
+    mentionIndicators.push(MENTION_STYLE_DEFAULT_KEY);
+
+  return expandMentionStylesForIndicators(
+    htmlStyle?.mention,
+    mentionIndicators
+  );
+}
+
 export function htmlStyleToCSSVariables(htmlStyle?: HtmlStyle): CSSProperties {
   const vars: Record<string, string> = {};
   applyCodeVars(vars, htmlStyle?.code);
@@ -155,5 +218,9 @@ export function htmlStyleToCSSVariables(htmlStyle?: HtmlStyle): CSSProperties {
   applyUnorderedListVars(vars, htmlStyle?.ul);
   applyOrderedListVars(vars, htmlStyle?.ol);
   applyCheckboxListVars(vars, htmlStyle?.ulCheckbox);
+  applyMentionVars(
+    vars,
+    expandMentionStylesForIndicatorsIncludeDefault(htmlStyle)
+  );
   return vars as CSSProperties;
 }

--- a/src/web/styleConversion/mentionIndicatorCssKey.ts
+++ b/src/web/styleConversion/mentionIndicatorCssKey.ts
@@ -1,0 +1,14 @@
+export const MENTION_STYLE_DEFAULT_KEY = 'default';
+
+export function indicatorToMentionCssKey(indicator: string): string {
+  if (indicator === MENTION_STYLE_DEFAULT_KEY) {
+    return MENTION_STYLE_DEFAULT_KEY;
+  }
+
+  const cp = indicator.codePointAt(0);
+  if (cp === undefined) {
+    return 'u0000';
+  }
+  const hex = cp.toString(16).toUpperCase();
+  return 'u' + hex.padStart(Math.max(4, hex.length), '0');
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

+ added handling of `htmlStyle` for mentions
+ Styling for mentions is a bit different than for the rest of the styles, because we cannot write out all the css rules in `EnrichedTextInput.css`(as we do not know all of the indicators up front). So like for the rest of the styles we still create css vars, in this case e.g. `--eti-mention-u0040-color` in this case `u0040` is escaped version of `@` as we cannot use `@` in a css variable. We also generate css rules dynamically, we always generate a rule `.eti-editor mention` for the default case, which works for any `<mention>` tag, and rules of form `.edit mention[indicator='@']` for specific indicators. Those specific css rules overwrite the default/general one. Finally we render those new css rules in a `<style>` tag.

## Test Plan

+ Launch example-web app
+ Play around with `apps/example-web/src/defaultHtmlStyle.ts` to see how the mention styling changes

## Screenshots / Videos

<img width="805" height="479" alt="image" src="https://github.com/user-attachments/assets/8a0ed407-af8f-4c4a-aa16-8893eff4cb0a" />
## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |
| Web |    ✅     |


## Checklist

- [x] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
