### PR TITLE
fix(iOS): apply zero width space for headings

### DIFF
--- a/.maestro/enrichedInput/flows/conflicting_paragraph_merge.yaml
+++ b/.maestro/enrichedInput/flows/conflicting_paragraph_merge.yaml
@@ -28,8 +28,6 @@ appId: swmansion.enriched.example
 - pressKey: Backspace
 
 - runFlow:
-    when:
-        platform: "android"
     commands:
         - pressKey: Backspace
 - inputText: " "

--- a/ios/inputAttributesManager/InputAttributesManager.mm
+++ b/ios/inputAttributesManager/InputAttributesManager.mm
@@ -192,8 +192,9 @@
     newAttrs[entry.key] = entry.value;
   }
 
-  // Apply active styles to typing attributes so the cursor correctly reflects
-  // the current formatting state (e.g. heading size).
+  // Apply active styles to typing attributes only for styles that require it so
+  // the cursor correctly reflects the current formatting state (e.g. heading
+  // size).
   for (StyleBase *style in _input->stylesDict.allValues) {
     if ([style appliesStylingToTyping] && [style detect:selectedRange]) {
       [style applyStylingToTypingAttrs:newAttrs];

--- a/ios/inputAttributesManager/InputAttributesManager.mm
+++ b/ios/inputAttributesManager/InputAttributesManager.mm
@@ -192,6 +192,14 @@
     newAttrs[entry.key] = entry.value;
   }
 
+  // Apply active styles to typing attributes so the cursor correctly reflects
+  // the current formatting state (e.g. heading size).
+  for (StyleBase *style in _input->stylesDict.allValues) {
+    if ([style appliesStylingToTyping] && [style detect:selectedRange]) {
+      [style applyStylingToTypingAttrs:newAttrs];
+    }
+  }
+
   textView.typingAttributes = newAttrs;
 }
 

--- a/ios/interfaces/StyleBase.h
+++ b/ios/interfaces/StyleBase.h
@@ -12,6 +12,7 @@
 - (NSString *)getValue;
 - (BOOL)isParagraph;
 - (BOOL)needsZWS;
+- (BOOL)appliesStylingToTyping;
 - (instancetype)initWithHost:(id<EnrichedViewHost>)host;
 - (NSRange)actualUsedRange:(NSRange)range;
 - (void)toggle:(NSRange)range;
@@ -30,6 +31,7 @@
 - (BOOL)any:(NSRange)range;
 - (NSArray<StylePair *> *)all:(NSRange)range;
 - (void)applyStyling:(NSRange)range;
+- (void)applyStylingToTypingAttrs:(NSMutableDictionary *)attributes;
 - (void)reapplyFromStylePair:(StylePair *)pair;
 - (AttributeEntry *)getEntryIfPresent:(NSRange)range;
 @end

--- a/ios/interfaces/StyleBase.mm
+++ b/ios/interfaces/StyleBase.mm
@@ -236,7 +236,7 @@
 - (void)applyStyling:(NSRange)range {
 }
 
-// This method gets overridden
+// This method gets overridden when the style needs to apply certain typing attributes
 - (void)applyStylingToTypingAttrs:(NSMutableDictionary *)attributes {
 }
 

--- a/ios/interfaces/StyleBase.mm
+++ b/ios/interfaces/StyleBase.mm
@@ -34,6 +34,10 @@
   return NO;
 }
 
+- (BOOL)appliesStylingToTyping {
+  return NO;
+}
+
 - (instancetype)initWithHost:(id<EnrichedViewHost>)host {
   self = [super init];
   _host = host;
@@ -230,6 +234,10 @@
 
 // This method gets overridden
 - (void)applyStyling:(NSRange)range {
+}
+
+// This method gets overridden
+- (void)applyStylingToTypingAttrs:(NSMutableDictionary *)attributes {
 }
 
 // Called during dirty range re-application to restore a style from a saved

--- a/ios/interfaces/StyleBase.mm
+++ b/ios/interfaces/StyleBase.mm
@@ -236,7 +236,8 @@
 - (void)applyStyling:(NSRange)range {
 }
 
-// This method gets overridden when the style needs to apply certain typing attributes
+// This method gets overridden when the style needs to apply certain typing
+// attributes
 - (void)applyStylingToTypingAttrs:(NSMutableDictionary *)attributes {
 }
 

--- a/ios/styles/HeadingStyleBase.mm
+++ b/ios/styles/HeadingStyleBase.mm
@@ -22,6 +22,14 @@
   return YES;
 }
 
+- (BOOL)needsZWS {
+  return YES;
+}
+
+- (BOOL)appliesStylingToTyping {
+  return YES;
+}
+
 - (void)applyStyling:(NSRange)range {
   [self.host.textView.textStorage
       enumerateAttribute:NSFontAttributeName
@@ -40,6 +48,21 @@
                                                        value:newFont
                                                        range:subRange];
               }];
+}
+
+- (void)applyStylingToTypingAttrs:(NSMutableDictionary *)attributes {
+  UIFont *currentFont = attributes[NSFontAttributeName];
+
+  if (currentFont == nil) {
+    currentFont = [self.host.config primaryFont];
+  }
+
+  UIFont *newFont = [currentFont setSize:[self getHeadingFontSize]];
+  if ([self isHeadingBold]) {
+    newFont = [newFont setBold];
+  }
+
+  attributes[NSFontAttributeName] = newFont;
 }
 
 // used to make sure headings dont persist after a newline is placed

--- a/ios/styles/HeadingStyleBase.mm
+++ b/ios/styles/HeadingStyleBase.mm
@@ -71,6 +71,15 @@
   if ([self detect:self.host.textView.selectedRange] && text.length > 0 &&
       [[NSCharacterSet newlineCharacterSet]
           characterIsMember:[text characterAtIndex:text.length - 1]]) {
+    // If the cursor sits directly before a ZWS, skip past it so the newline
+    // is appended after the ZWS. This keeps the ZWS (and the heading) on the
+    // current line while the new line the cursor lands on has no heading.
+    // Without this the lone '\n' inherits heading attributes
+    NSString *string = self.host.textView.textStorage.string;
+    if (range.length == 0 && range.location < string.length &&
+        [string characterAtIndex:range.location] == 0x200B) {
+      range = NSMakeRange(range.location + 1, 0);
+    }
     // do the replacement manually
     [TextInsertionUtils replaceText:text
                                  at:range

--- a/ios/utils/ZeroWidthSpaceUtils.mm
+++ b/ios/utils/ZeroWidthSpaceUtils.mm
@@ -142,7 +142,7 @@
                                host:host
                       withSelection:NO];
     offset += 1;
-    if ([index integerValue] <= preAddSelection.location) {
+    if ([index integerValue] < preAddSelection.location) {
       postAddLocationOffset += 1;
     }
     if ([index integerValue] >= preAddSelection.location &&
@@ -164,11 +164,6 @@
                 additionalAttributes:metaAttrs
                                 host:host
                        withSelection:NO];
-      // If the cursor was at the end of the input, it's now 'trapped' before
-      // the ZWS. We must bump it forward by 1.
-      if (preAddSelection.location == lastRange.location) {
-        postAddLocationOffset += 1;
-      }
     }
   }
 

--- a/ios/utils/ZeroWidthSpaceUtils.mm
+++ b/ios/utils/ZeroWidthSpaceUtils.mm
@@ -142,7 +142,7 @@
                                host:host
                       withSelection:NO];
     offset += 1;
-    if ([index integerValue] < preAddSelection.location) {
+    if ([index integerValue] <= preAddSelection.location) {
       postAddLocationOffset += 1;
     }
     if ([index integerValue] >= preAddSelection.location &&
@@ -164,6 +164,11 @@
                 additionalAttributes:metaAttrs
                                 host:host
                        withSelection:NO];
+      // If the cursor was at the end of the input, it's now 'trapped' before
+      // the ZWS. We must bump it forward by 1.
+      if (preAddSelection.location == lastRange.location) {
+        postAddLocationOffset += 1;
+      }
     }
   }
 


### PR DESCRIPTION
# Summary

This PR: 

- apply zero width space for headings
- adds `applyStylingToTypingAttrs` method in `StyleBase` to properly align cursor styles on empty line

## Test Plan

Play around with headings, and check If the style work properly, cursor is properly styled.

## Screenshots / Videos
Before:

https://github.com/user-attachments/assets/965e8d58-21dc-4f0e-a9b4-8c8ea69084dd


After:

https://github.com/user-attachments/assets/97b5ee50-5fc5-4908-b5ad-dff5858cb10c


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [x] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
