### PR TITLE
fix: rename default to auto alignment value

### DIFF
--- a/docs/INPUT_API_REFERENCE.md
+++ b/docs/INPUT_API_REFERENCE.md
@@ -299,7 +299,7 @@ interface OnChangeStateEvent {
 - `isActive` indicates if the style is active within current selection.
 - `isBlocking` indicates if the style is blocked by other currently active, meaning it can't be toggled.
 - `isConflicting` indicates if the style is in conflict with other currently active styles, meaning toggling it will remove conflicting style.
-- `alignment` indicates the current text alignment of the paragraph at the cursor position. Possible values: `'left'`, `'center'`, `'right'`, `'justify'`.
+- `alignment` indicates the current text alignment of the paragraph at the cursor position. Possible values: `'left'`, `'center'`, `'right'`, `'justify'`, `'auto'`.
 
 | Type                                                        | Platform |
 |-------------------------------------------------------------|----------|
@@ -609,12 +609,15 @@ Sets the selection at the given indexes.
 ### `.setTextAlignment()`
 
 ```ts
-setTextAlignment: (alignment: 'left' | 'center' | 'right' | 'justify' | 'default') => void;
+setTextAlignment: (alignment: 'left' | 'center' | 'right' | 'justify' | 'auto') => void;
 ```
 
 Sets text alignment for the paragraph(s) at the current selection. When inside a list, the alignment is applied to all contiguous list items.
 
-- `alignment` - the desired text alignment. Use `'default'` to reset to the system natural alignment.
+- `alignment` - the desired text alignment. Use `'auto'` to reset to the system natural alignment.
+
+> [!NOTE]
+> This method is iOS only.
 
 ### `.startMention()`
 

--- a/docs/INPUT_API_REFERENCE.md
+++ b/docs/INPUT_API_REFERENCE.md
@@ -617,7 +617,7 @@ Sets text alignment for the paragraph(s) at the current selection. When inside a
 - `alignment` - the desired text alignment. Use `'auto'` to reset to the system natural alignment.
 
 > [!NOTE]
-> This method is iOS only.
+> This method is iOS only for now.
 
 ### `.startMention()`
 

--- a/ios/utils/AlignmentUtils.mm
+++ b/ios/utils/AlignmentUtils.mm
@@ -16,7 +16,7 @@
     return @"justify";
   case NSTextAlignmentNatural:
   default:
-    return @"left";
+    return @"auto";
   }
 }
 
@@ -68,6 +68,8 @@
 
 + (NSString *)cssValueForAlignment:(NSTextAlignment)alignment {
   switch (alignment) {
+  case NSTextAlignmentLeft:
+    return @"left";
   case NSTextAlignmentCenter:
     return @"center";
   case NSTextAlignmentRight:

--- a/src/native/EnrichedTextInput.tsx
+++ b/src/native/EnrichedTextInput.tsx
@@ -271,7 +271,7 @@ export const EnrichedTextInput = ({
       Commands.setSelection(nullthrows(nativeRef.current), start, end);
     },
     setTextAlignment: (
-      alignment: 'left' | 'center' | 'right' | 'justify' | 'default'
+      alignment: 'left' | 'center' | 'right' | 'justify' | 'auto'
     ) => {
       Commands.setTextAlignment(nullthrows(nativeRef.current), alignment);
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -426,7 +426,7 @@ export interface EnrichedTextInputInstance extends NativeMethods {
     attributes?: Record<string, string>
   ) => void;
   setTextAlignment: (
-    alignment: 'left' | 'center' | 'right' | 'justify' | 'default'
+    alignment: 'left' | 'center' | 'right' | 'justify' | 'auto'
   ) => void;
 }
 


### PR DESCRIPTION

# Summary

This PR:
Updates readme for text alignment
Refactors `default` to `auto` in alignment

## Test Plan

Run example app and play around with alignment. 
When we do not set any alignment html should not contain `style-"text-alignment: ..."`

## Screenshots / Videos

https://github.com/user-attachments/assets/47e53faf-76ff-450f-a121-f8e11b430bd4


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
