### PR TITLE
fix(ios): removed selection change event emition on input focus

### DIFF
--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -1748,15 +1748,6 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
     if (_emitFocusBlur) {
       emitter->onInputFocus({});
     }
-
-    NSString *textAtSelection =
-        [[[NSMutableString alloc] initWithString:textView.textStorage.string]
-            substringWithRange:textView.selectedRange];
-    emitter->onChangeSelection(
-        {.start = static_cast<int>(textView.selectedRange.location),
-         .end = static_cast<int>(textView.selectedRange.location +
-                                 textView.selectedRange.length),
-         .text = [textAtSelection toCppString]});
   }
   // manage selection changes since textViewDidChangeSelection sometimes doesn't
   // run on focus


### PR DESCRIPTION
# Summary

- on iOS there was an inconsistency with `selectionChange` events in comparison with other platforms
- `selectionChange` event was emitted every time we focused on the input, which was inconsistent and emitted a confusing event about selection change, even though its state never changed internally
- this also introduced a path when we blurred the input and then focused on a different part of the text that we blurred on, two `selectionChange` events were emitted unnecessarily

## Videos

Comparison of changes

Before:

https://github.com/user-attachments/assets/34cf4003-ab1b-4e74-8b20-f163c4a8623d

After:

https://github.com/user-attachments/assets/472b92e9-0db8-4a7d-bee6-62c7d217e8ac

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)