### PR TITLE
feat(web): undo, redo

### DIFF
--- a/.playwright/helpers/selection.ts
+++ b/.playwright/helpers/selection.ts
@@ -28,3 +28,17 @@ export async function selectParagraphTextInclusive(
     { from: fromIndex, to: toIndex }
   );
 }
+
+export async function selectRange(page: Page, start: number, end: number) {
+  await page.keyboard.press('Home');
+
+  for (let i = 0; i < start; i++) {
+    await page.keyboard.press('ArrowRight');
+  }
+
+  await page.keyboard.down('Shift');
+  for (let i = 0; i < end - start; i++) {
+    await page.keyboard.press('ArrowRight');
+  }
+  await page.keyboard.up('Shift');
+}

--- a/.playwright/tests/undoRedo.spec.ts
+++ b/.playwright/tests/undoRedo.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect, type Page } from '@playwright/test';
+
+import {
+  focusEnrichedEditable,
+  getSerializedHtml,
+  gotoVisualRegression,
+} from '../helpers/visual-regression';
+import { toolbarButton } from '../helpers/toolbar';
+import { selectRange } from '../helpers/selection';
+
+// Tiptap History debounces consecutive typing into a single
+// undo entry for ~500ms. Waiting past that creates separate
+// entries that can be undone independently.
+const HISTORY_GROUP_DELAY = 600;
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+async function pressUndo(page: Page) {
+  await page.keyboard.press(`${MOD}+z`);
+}
+
+async function pressRedo(page: Page) {
+  await page.keyboard.press(`${MOD}+Shift+z`);
+}
+
+test.describe('undo / redo', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoVisualRegression(page);
+    await focusEnrichedEditable(page);
+  });
+
+  test('undoes plain typed text', async ({ page }) => {
+    await page.keyboard.type('Hello');
+    await page.waitForTimeout(HISTORY_GROUP_DELAY);
+    await page.keyboard.type(' World');
+
+    expect(await getSerializedHtml(page)).toEqual(
+      '<html><p>Hello World</p></html>'
+    );
+
+    await pressUndo(page);
+
+    const after = await getSerializedHtml(page);
+    expect(after).toEqual('<html><p>Hello</p></html>');
+  });
+
+  test('undoes and redoes plain typed text', async ({ page }) => {
+    await page.keyboard.type('Hello');
+    await page.waitForTimeout(HISTORY_GROUP_DELAY);
+    await page.keyboard.type(' World');
+    await page.waitForTimeout(HISTORY_GROUP_DELAY);
+    await page.keyboard.type('!');
+
+    await pressUndo(page);
+    expect(await getSerializedHtml(page)).toEqual(
+      '<html><p>Hello World</p></html>'
+    );
+
+    await pressUndo(page);
+    expect(await getSerializedHtml(page)).toEqual('<html><p>Hello</p></html>');
+
+    await pressRedo(page);
+    expect(await getSerializedHtml(page)).toEqual(
+      '<html><p>Hello World</p></html>'
+    );
+
+    await pressRedo(page);
+    expect(await getSerializedHtml(page)).toEqual(
+      '<html><p>Hello World!</p></html>'
+    );
+  });
+
+  test('undoes a bold style applied to a selection', async ({ page }) => {
+    await page.keyboard.type('Hello World');
+    await page.waitForTimeout(HISTORY_GROUP_DELAY);
+
+    await page.keyboard.press(`${MOD}+a`);
+    await toolbarButton(page, 'bold').click();
+
+    expect(await getSerializedHtml(page)).toEqual(
+      '<html><p><b>Hello World</b></p></html>'
+    );
+
+    await pressUndo(page);
+
+    const after = await getSerializedHtml(page);
+    expect(after).toEqual('<html><p>Hello World</p></html>');
+  });
+
+  test('undoes and redoes a bold style applied to a selection', async ({
+    page,
+  }) => {
+    await page.keyboard.type('Hello World!');
+    await page.waitForTimeout(HISTORY_GROUP_DELAY);
+
+    await page.keyboard.press(`${MOD}+a`);
+    await toolbarButton(page, 'bold').click();
+    await page.waitForTimeout(HISTORY_GROUP_DELAY);
+    await selectRange(page, 6, 11);
+    await toolbarButton(page, 'italic').click();
+    expect(await getSerializedHtml(page)).toEqual(
+      '<html><p><b>Hello <i>World</i>!</b></p></html>'
+    );
+
+    await pressUndo(page);
+    expect(await getSerializedHtml(page)).toEqual(
+      '<html><p><b>Hello World!</b></p></html>'
+    );
+
+    await pressRedo(page);
+    expect(await getSerializedHtml(page)).toEqual(
+      '<html><p><b>Hello <i>World</i>!</b></p></html>'
+    );
+  });
+
+  test('undoes a heading paragraph style', async ({ page }) => {
+    await page.keyboard.type('Hello');
+    await page.waitForTimeout(HISTORY_GROUP_DELAY);
+
+    await toolbarButton(page, 'h1').click();
+    expect(await getSerializedHtml(page)).toEqual(
+      '<html><h1>Hello</h1></html>'
+    );
+
+    await pressUndo(page);
+
+    const after = await getSerializedHtml(page);
+    expect(after).toEqual('<html><p>Hello</p></html>');
+  });
+
+  test('undoes and redoes a heading paragraph style', async ({ page }) => {
+    await page.keyboard.type('Hello World!');
+    await page.waitForTimeout(HISTORY_GROUP_DELAY);
+
+    await selectRange(page, 6, 11);
+    await toolbarButton(page, 'bold').click();
+    await page.waitForTimeout(HISTORY_GROUP_DELAY);
+
+    await toolbarButton(page, 'h1').click();
+    await pressUndo(page);
+
+    expect(await getSerializedHtml(page)).toEqual(
+      '<html><p>Hello <b>World</b>!</p></html>'
+    );
+
+    await pressRedo(page);
+    expect(await getSerializedHtml(page)).toEqual(
+      '<html><h1>Hello World!</h1></html>'
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@tiptap/extension-code": "3.20.4",
     "@tiptap/extension-document": "3.20.4",
     "@tiptap/extension-heading": "3.20.4",
+    "@tiptap/extension-history": "3.20.4",
     "@tiptap/extension-image": "3.20.4",
     "@tiptap/extension-italic": "3.20.4",
     "@tiptap/extension-link": "3.20.4",

--- a/src/web/EnrichedTextInput.tsx
+++ b/src/web/EnrichedTextInput.tsx
@@ -26,6 +26,7 @@ import {
 import Document from '@tiptap/extension-document';
 import Paragraph from '@tiptap/extension-paragraph';
 import Text from '@tiptap/extension-text';
+import History from '@tiptap/extension-history';
 import { Placeholder } from '@tiptap/extensions/placeholder';
 import { useOnChangeHtml } from './useOnChangeHtml';
 import { useOnChangeText } from './useOnChangeText';
@@ -183,6 +184,7 @@ export const EnrichedTextInput = ({
       Document,
       Paragraph,
       Text,
+      History,
       EnrichedBold,
       EnrichedItalic,
       EnrichedUnderline,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4165,6 +4165,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tiptap/extension-history@npm:3.20.4":
+  version: 3.20.4
+  resolution: "@tiptap/extension-history@npm:3.20.4"
+  peerDependencies:
+    "@tiptap/extensions": ^3.20.4
+  checksum: 10c0/fbaae9e3fffb7ae224eaa290d1f2f753cdc8a8951004a271054c48f32d3f1866f4640226a651856f092cf561016f2d9f7c647bd5a3effbbfcad78283f13d42bc
+  languageName: node
+  linkType: hard
+
 "@tiptap/extension-image@npm:3.20.4":
   version: 3.20.4
   resolution: "@tiptap/extension-image@npm:3.20.4"
@@ -12683,6 +12692,7 @@ __metadata:
     "@tiptap/extension-code": "npm:3.20.4"
     "@tiptap/extension-document": "npm:3.20.4"
     "@tiptap/extension-heading": "npm:3.20.4"
+    "@tiptap/extension-history": "npm:3.20.4"
     "@tiptap/extension-image": "npm:3.20.4"
     "@tiptap/extension-italic": "npm:3.20.4"
     "@tiptap/extension-link": "npm:3.20.4"


### PR DESCRIPTION
# Summary

Implemented input changes history using a built-in extension for *Tiptap*

## Test Plan

You can use this feature using default system shortcuts.

For example when using MacOS it will be

- <kbd>⌘</kbd> + <kbd>Z</kbd> → Undo
- <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>Z</kbd> → Redo

## Videos

Example usage

https://github.com/user-attachments/assets/a484ddb0-6fe1-4a10-b6f7-417c978ae5c9

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |

## Checklist

- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)
