### PR TITLE
fix(android): remove heading style when backspacing ZWS

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/textinput/styles/ParagraphStyles.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/styles/ParagraphStyles.kt
@@ -338,21 +338,21 @@ class ParagraphStyles(
       }
 
       if (isNewLine) {
-        if (!config.isContinuous) {
-          spanState.setStart(style, null)
-          continue
-        }
-
         // If removing text at the beginning of the line, we want to remove the span for the whole paragraph
         if (isBackspace) {
           val currentParagraphBounds = s.getParagraphBounds(endCursorPosition)
           removeSpansForRange(s, currentParagraphBounds.first, currentParagraphBounds.second, config.clazz)
           spanState.setStart(style, null)
           continue
-        } else {
-          s.insert(endCursorPosition, EnrichedConstants.ZWS_STRING)
-          endCursorPosition += 1
         }
+
+        if (!config.isContinuous) {
+          spanState.setStart(style, null)
+          continue
+        }
+
+        s.insert(endCursorPosition, EnrichedConstants.ZWS_STRING)
+        endCursorPosition += 1
       }
 
       var (start, end) = s.getParagraphBounds(styleStart, endCursorPosition)

--- a/android/src/main/java/com/swmansion/enriched/textinput/watchers/EnrichedTextWatcher.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/watchers/EnrichedTextWatcher.kt
@@ -41,6 +41,7 @@ class EnrichedTextWatcher(
 
     if (view.isDuringTransaction) return
     applyStyles(s)
+    view.layoutManager.invalidateLayout()
   }
 
   private fun applyStyles(s: Editable) {


### PR DESCRIPTION
# Summary

Fixes: #476  

## Test Plan

Test if the backspace at the beginning of heading properly removes heading style.

## Screenshots / Videos

https://github.com/user-attachments/assets/88bd3ce7-18d9-4d7b-9307-ac1e84104107


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

- [x] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
