### PR TITLE
fix(iOS): rendering numeric entities

### DIFF
--- a/ios/extensions/StringExtension.mm
+++ b/ios/extensions/StringExtension.mm
@@ -83,9 +83,10 @@
                         codePoint = (UTF32Char)strtoul(decStr, NULL, 10);
                       }
 
-                      // Safety check: Valid Unicode scalar values are 0x1..0x10FFFF,
-                      // excluding surrogate code points (0xD800-0xDFFF). Replace invalid
-                      // values with U+FFFD (Replacement Character) to avoid crashes/truncation.
+                      // Safety check: Valid Unicode scalar values are
+                      // 0x1..0x10FFFF, excluding surrogate code points
+                      // (0xD800-0xDFFF). Replace invalid values with U+FFFD
+                      // (Replacement Character) to avoid crashes/truncation.
                       if (codePoint == 0 || codePoint > 0x10FFFF ||
                           (codePoint >= 0xD800 && codePoint <= 0xDFFF)) {
                         codePoint = 0xFFFD;

--- a/ios/extensions/StringExtension.mm
+++ b/ios/extensions/StringExtension.mm
@@ -63,6 +63,9 @@
                          range:NSMakeRange(0, text.length)
                     usingBlock:^(NSTextCheckingResult *match,
                                  NSMatchingFlags flags, BOOL *stop) {
+                      if (match == nil) {
+                        return;
+                      }
                       NSRange fullRange = [match range];
                       NSString *entityStr = [text substringWithRange:fullRange];
                       NSString *valueStr =
@@ -83,10 +86,12 @@
                         codePoint = (UTF32Char)strtoul(decStr, NULL, 10);
                       }
 
-                      // Safety check: Valid Unicode scalar values are
-                      // 0x1..0x10FFFF, excluding surrogate code points
-                      // (0xD800-0xDFFF). Replace invalid values with U+FFFD
-                      // (Replacement Character) to avoid crashes/truncation.
+                      // Safety check: HTML numeric character references should
+                      // map to valid Unicode scalar values (0x0..0x10FFFF),
+                      // excluding surrogate code points (0xD800-0xDFFF). Per
+                      // HTML5, code point 0 is treated as U+FFFD. Replace
+                      // invalid values with U+FFFD (Replacement Character) to
+                      // avoid crashes/truncation.
                       if (codePoint == 0 || codePoint > 0x10FFFF ||
                           (codePoint >= 0xD800 && codePoint <= 0xDFFF)) {
                         codePoint = 0xFFFD;

--- a/ios/extensions/StringExtension.mm
+++ b/ios/extensions/StringExtension.mm
@@ -51,6 +51,75 @@
     }
   }
 
+  // Numeric character references: &#NNNN; (decimal) and &#xHHHH; (hex)
+  NSRegularExpression *numericEntityRegex = [NSRegularExpression
+      regularExpressionWithPattern:@"&#(x[0-9a-fA-F]+|[0-9]+);"
+                           options:0
+                             error:nil];
+
+  [numericEntityRegex
+      enumerateMatchesInString:text
+                       options:0
+                         range:NSMakeRange(0, text.length)
+                    usingBlock:^(NSTextCheckingResult *match,
+                                 NSMatchingFlags flags, BOOL *stop) {
+                      NSRange fullRange = [match range];
+                      NSString *entityStr = [text substringWithRange:fullRange];
+                      NSString *valueStr =
+                          [text substringWithRange:[match rangeAtIndex:1]];
+
+                      // Convert the matched string into a raw integer (UTF32
+                      // Code Point)
+                      UTF32Char codePoint = 0;
+                      if ([valueStr hasPrefix:@"x"] ||
+                          [valueStr hasPrefix:@"X"]) {
+                        // Parse Hexadecimal (base 16)
+                        const char *hexStr =
+                            [[valueStr substringFromIndex:1] UTF8String];
+                        codePoint = (UTF32Char)strtoul(hexStr, NULL, 16);
+                      } else {
+                        // Parse Decimal (base 10)
+                        const char *decStr = [valueStr UTF8String];
+                        codePoint = (UTF32Char)strtoul(decStr, NULL, 10);
+                      }
+
+                      // Safety check: The highest valid Unicode character is
+                      // 0x10FFFF. If the parsed number is larger than this,
+                      // it's invalid/corrupted data. We replace it with the
+                      // standard "Replacement Character" () to prevent crashes.
+                      if (codePoint > 0x10FFFF) {
+                        codePoint = 0xFFFD;
+                      }
+
+                      NSString *decoded;
+                      if (codePoint <= 0xFFFF) {
+                        // STANDARD CHARACTER: Fits perfectly in one 16-bit
+                        // unichar.
+                        unichar ch = (unichar)codePoint;
+                        decoded = [NSString stringWithCharacters:&ch length:1];
+                      } else {
+                        // LARGE CHARACTER: Too big for 16 bits.
+                        // We must split the code point into two 16-bit halves
+                        // (a "Surrogate Pair") so NSString can store it
+                        // properly in UTF-16.
+                        UniChar surrogate[2];
+
+                        // Calculate the "High" surrogate half
+                        surrogate[0] =
+                            (UniChar)(0xD800 + ((codePoint - 0x10000) >> 10));
+
+                        // Calculate the "Low" surrogate half
+                        surrogate[1] =
+                            (UniChar)(0xDC00 + ((codePoint - 0x10000) & 0x3FF));
+
+                        // Create the string using both 16-bit pieces
+                        decoded = [NSString stringWithCharacters:surrogate
+                                                          length:2];
+                      }
+
+                      results[@(fullRange.location)] = @[ entityStr, decoded ];
+                    }];
+
   return results;
 }
 

--- a/ios/extensions/StringExtension.mm
+++ b/ios/extensions/StringExtension.mm
@@ -53,7 +53,7 @@
 
   // Numeric character references: &#NNNN; (decimal) and &#xHHHH; (hex)
   NSRegularExpression *numericEntityRegex = [NSRegularExpression
-      regularExpressionWithPattern:@"&#(x[0-9a-fA-F]+|[0-9]+);"
+      regularExpressionWithPattern:@"&#([xX][0-9a-fA-F]+|[0-9]+);"
                            options:0
                              error:nil];
 

--- a/ios/extensions/StringExtension.mm
+++ b/ios/extensions/StringExtension.mm
@@ -83,11 +83,11 @@
                         codePoint = (UTF32Char)strtoul(decStr, NULL, 10);
                       }
 
-                      // Safety check: The highest valid Unicode character is
-                      // 0x10FFFF. If the parsed number is larger than this,
-                      // it's invalid/corrupted data. We replace it with the
-                      // standard "Replacement Character" () to prevent crashes.
-                      if (codePoint > 0x10FFFF) {
+                      // Safety check: Valid Unicode scalar values are 0x1..0x10FFFF,
+                      // excluding surrogate code points (0xD800-0xDFFF). Replace invalid
+                      // values with U+FFFD (Replacement Character) to avoid crashes/truncation.
+                      if (codePoint == 0 || codePoint > 0x10FFFF ||
+                          (codePoint >= 0xD800 && codePoint <= 0xDFFF)) {
                         codePoint = 0xFFFD;
                       }
 


### PR DESCRIPTION
# Summary
Fixes: #636 

This PR adds support for numeric character references (both decimal and hexadecimal), for example: &#29992; and &#x7528;.

## Test Plan

Run reproduction steps from issue: #636
Issue should be resolved.

## Screenshots / Videos

https://github.com/user-attachments/assets/f6be0e7d-df27-4794-a972-9b5c910b1a3f


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [x] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
