### PR TITLE
fix(iOS): image y positioning

### DIFF
--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -1743,7 +1743,6 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
   [self tryUpdatingHeight];
   // update active styles as well
   [self tryUpdatingActiveStyles];
-  [self layoutAttachments];
   // update drawing - schedule debounced relayout
   [self scheduleRelayoutIfNeeded];
 }
@@ -1783,6 +1782,9 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
     // measureSize may not be up-to date at that point
     CGSize measuredSize = [self measureSize:self->textView.frame.size.width];
     self->textView.contentSize = measuredSize;
+
+    // Re-position attachment image views after the forced full re-layout
+    [self layoutAttachments];
   });
 }
 


### PR DESCRIPTION
# Summary

This PR fixes image y positioning

## Test Plan

1. Insert Image into input
2. Add remove text before/after the image
3. Image should not jump


## Screenshots / Videos
Before:

https://github.com/user-attachments/assets/4aae93b9-ca1f-4866-88bf-b069cb507780


After:


https://github.com/user-attachments/assets/0ba98088-ec4e-484a-b5d1-3a2a83e9651a


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [X] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
