### PR TITLE
chore: pin shell-quote to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,9 @@
     "apps/example",
     "apps/example-web"
   ],
+  "resolutions": {
+    "shell-quote": "1.8.4"
+  },
   "packageManager": "yarn@4.13.0",
   "jest": {
     "projects": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -13797,10 +13797,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.6.1, shell-quote@npm:^1.8.1":
-  version: 1.8.2
-  resolution: "shell-quote@npm:1.8.2"
-  checksum: 10c0/85fdd44f2ad76e723d34eb72c753f04d847ab64e9f1f10677e3f518d0e5b0752a176fd805297b30bb8c3a1556ebe6e77d2288dbd7b7b0110c7e941e9e9c20ce1
+"shell-quote@npm:1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10c0/86c93678bc394cb81f5ddcdc87df9c95d279ef9652775cd1cd1eed361404169a8d8cbaacaeed232ab09919e36ee1e5363863570390d78571f8c22b7f6312fb40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

Fixes shell-quote vulnerability: https://security.snyk.io/package/npm/shell-quote/1.8.2
Fixes: https://github.com/software-mansion/react-native-enriched-html/pull/646

