### PR TITLE
fix(iOS): rendering images from html with link

### DIFF
--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -2026,7 +2026,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: c00c20551d40126351a6783c47ce75f5b374851b
-  hermes-engine: 484c595d9e6a0b7b7607e8ead508ba5c472493c7
+  hermes-engine: b4dad6ba67535bb03c8ff1006b337cba14db16cb
   RCTDeprecation: 3bb167081b134461cfeb875ff7ae1945f8635257
   RCTRequired: 74839f55d5058a133a0bc4569b0afec750957f64
   RCTSwiftUI: 87a316382f3eab4dd13d2a0d0fd2adcce917361a
@@ -2035,7 +2035,7 @@ SPEC CHECKSUMS:
   React: 1b1536b9099195944034e65b1830f463caaa8390
   React-callinvoker: 6dff6d17d1d6cc8fdf85468a649bafed473c65f5
   React-Core: 39ee05b5798296f433dd3c3624c57a187c1510e3
-  React-Core-prebuilt: 3ca7a49d919f940e7de8fb0c2a3f5cfcb665f09b
+  React-Core-prebuilt: 69556f895326f23c007f3a6869340045d7dca106
   React-CoreModules: e78bfd2617075bc0e50c689df4a29232bd72ad82
   React-cxxreact: 3fe21801d46097cf74c3dff6953677bebc4a3c2a
   React-debug: e1f00fcd2cef58a2897471a6d76a4ef5f5f90c74
@@ -2097,8 +2097,8 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 706b65371b90b5cc797b6639e8979f2e5cecd6da
   ReactCodegen: ab01ebfffac5cda9140204eb872ed97c15df225f
   ReactCommon: 47ef95b0920948a0b54d7439f7452501eeeac071
-  ReactNativeDependencies: 652705a9bc92800d0b1e15177a61ba70d89d24dd
-  ReactNativeEnrichedHtml: 93722241410f2daaa8c20ce6bcfcf4666bfd9166
+  ReactNativeDependencies: 8a208df374583424130645685d86306befc275cf
+  ReactNativeEnrichedHtml: 7d90df4aced7f533c7bd15ac296879b214413361
   Yoga: e83c3121d079541e69f3c5c623faaaf933fb5812
 
 PODFILE CHECKSUM: 88c10840d02e9884b2dc3f457d5120f83ac3803b

--- a/ios/htmlParser/HtmlParser.mm
+++ b/ios/htmlParser/HtmlParser.mm
@@ -645,6 +645,9 @@
 
   // process tags into proper StyleType + StylePair values
   NSMutableArray *processedStyles = [[NSMutableArray alloc] init];
+  // Tracks the number of processed images to remove their pre-generated
+  // placeholder offsets from tag ranges when reading from plainText
+  // (which does not contain those placeholders).
   NSInteger secondPassImageCount = 0;
 
   for (NSArray *arr in initiallyProcessedTags) {
@@ -749,17 +752,8 @@
       // placeholder, which don't exist in plainText. Subtract them to map
       // back to the correct plainText index.
       NSRange adjustedRange = tagRangeValue.rangeValue;
-      // Calculate the shifted location, ensuring it doesn't drop below 0
-      NSUInteger rawLoc = (adjustedRange.location >= secondPassImageCount)
-                              ? adjustedRange.location - secondPassImageCount
-                              : 0;
-      // Cap the location so it can never exceed the plain text length
-      NSUInteger plainLoc = MIN(rawLoc, plainText.length);
-      // Cap the length based on whatever space is left in the string
-      NSUInteger plainLen =
-          MIN(adjustedRange.length, plainText.length - plainLoc);
-
-      NSRange plainTextRange = NSMakeRange(plainLoc, plainLen);
+      NSRange plainTextRange = NSMakeRange(
+          adjustedRange.location - secondPassImageCount, adjustedRange.length);
       NSString *text = [plainText substringWithRange:plainTextRange];
 
       LinkData *linkData = [[LinkData alloc] init];

--- a/ios/htmlParser/HtmlParser.mm
+++ b/ios/htmlParser/HtmlParser.mm
@@ -645,6 +645,7 @@
 
   // process tags into proper StyleType + StylePair values
   NSMutableArray *processedStyles = [[NSMutableArray alloc] init];
+  NSInteger secondPassImageCount = 0;
 
   for (NSArray *arr in initiallyProcessedTags) {
     NSString *tagName = (NSString *)arr[0];
@@ -715,6 +716,7 @@
       }
 
       stylePair.styleValue = imageData;
+      secondPassImageCount++;
     } else if ([tagName isEqualToString:@"u"]) {
       [styleArr addObject:@([UnderlineStyle getType])];
     } else if ([tagName isEqualToString:@"s"]) {
@@ -742,7 +744,10 @@
       NSString *url =
           [params substringWithRange:NSMakeRange(hrefRange.location + 6,
                                                  hrefRange.length - 7)];
-      NSString *text = [plainText substringWithRange:tagRangeValue.rangeValue];
+      NSRange adjustedRange = tagRangeValue.rangeValue;
+      NSRange plainTextRange = NSMakeRange(
+          adjustedRange.location - secondPassImageCount, adjustedRange.length);
+      NSString *text = [plainText substringWithRange:plainTextRange];
 
       LinkData *linkData = [[LinkData alloc] init];
       linkData.url = url;

--- a/ios/htmlParser/HtmlParser.mm
+++ b/ios/htmlParser/HtmlParser.mm
@@ -744,9 +744,22 @@
       NSString *url =
           [params substringWithRange:NSMakeRange(hrefRange.location + 6,
                                                  hrefRange.length - 7)];
+
+      // tagRange location includes one extra offset per preceding image
+      // placeholder, which don't exist in plainText. Subtract them to map
+      // back to the correct plainText index.
       NSRange adjustedRange = tagRangeValue.rangeValue;
-      NSRange plainTextRange = NSMakeRange(
-          adjustedRange.location - secondPassImageCount, adjustedRange.length);
+      // Calculate the shifted location, ensuring it doesn't drop below 0
+      NSUInteger rawLoc = (adjustedRange.location >= secondPassImageCount)
+                              ? adjustedRange.location - secondPassImageCount
+                              : 0;
+      // Cap the location so it can never exceed the plain text length
+      NSUInteger plainLoc = MIN(rawLoc, plainText.length);
+      // Cap the length based on whatever space is left in the string
+      NSUInteger plainLen =
+          MIN(adjustedRange.length, plainText.length - plainLoc);
+
+      NSRange plainTextRange = NSMakeRange(plainLoc, plainLen);
       NSString *text = [plainText substringWithRange:plainTextRange];
 
       LinkData *linkData = [[LinkData alloc] init];


### PR DESCRIPTION
# Summary

Fixes: #661 

## Test Plan

Insert html by `Set input's value` button into example app:
`<html><p><img src="xxx" width="100" height="100"/><img src="xxx" width="100" height="100"/><img src="xxx" width="100" height="100"/></p><p>See  <a href="https://example.com">a link</a></p></html>`
The html should be parsed properly.

## Screenshots / Videos
before:


after:

https://github.com/user-attachments/assets/eb79f199-a5d5-4edc-ba4d-cc65074644aa


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Web     |    ❌     |

## Checklist

- [x] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
