### PR TITLE
fix(web): inline styles inheritance in newline

### DIFF
--- a/.playwright/tests/strictMarks.spec.ts
+++ b/.playwright/tests/strictMarks.spec.ts
@@ -143,6 +143,30 @@ test.describe('strict marks', () => {
     await expect(boldBtn).toHaveClass(/toolbar-btn--active/);
   });
 
+  test('pressing Enter in the middle of bold that is followed by plain text keeps bold and types bold', async ({
+    page,
+  }) => {
+    await setEditorHtml(page, '<html><p><b>hello</b> world</p></html>');
+
+    const editor = editorLocator(page);
+    const boldBtn = toolbarButton(page, 'bold');
+
+    await editor.click();
+    await editor.press('End');
+    // land in he|llo
+    for (let i = 0; i < 9; i++) {
+      await editor.press('ArrowLeft', { delay: 40 });
+    }
+
+    await editor.press('Enter');
+    await expect(boldBtn).toHaveClass(/toolbar-btn--active/);
+
+    await editor.pressSequentially('X', { delay: 40 });
+    await expect(boldBtn).toHaveClass(/toolbar-btn--active/);
+
+    await expect.poll(async () => getSerializedHtml(page)).toMatch(/<p><b>X/);
+  });
+
   test('pressing Enter after the last bold character keeps bold when the rest of the line is plain', async ({
     page,
   }) => {

--- a/.playwright/tests/strictMarks.spec.ts
+++ b/.playwright/tests/strictMarks.spec.ts
@@ -155,7 +155,7 @@ test.describe('strict marks', () => {
     await editor.press('End');
     // land in he|llo
     for (let i = 0; i < 9; i++) {
-      await editor.press('ArrowLeft', { delay: 40 });
+      await editor.press('ArrowLeft', { delay: 80 });
     }
 
     await editor.press('Enter');

--- a/.playwright/tests/strictMarks.spec.ts
+++ b/.playwright/tests/strictMarks.spec.ts
@@ -161,7 +161,7 @@ test.describe('strict marks', () => {
     await editor.press('Enter');
     await expect(boldBtn).toHaveClass(/toolbar-btn--active/);
 
-    await editor.pressSequentially('X', { delay: 40 });
+    await editor.pressSequentially('X', { delay: 80 });
     await expect(boldBtn).toHaveClass(/toolbar-btn--active/);
 
     await expect.poll(async () => getSerializedHtml(page)).toMatch(/<p><b>X/);

--- a/src/web/pmPlugins/StrictMarksPlugin.ts
+++ b/src/web/pmPlugins/StrictMarksPlugin.ts
@@ -104,6 +104,9 @@ export const StrictMarksPlugin = Extension.create({
           if (!selection.empty) return null;
 
           const docChanged = !oldState.doc.eq(newState.doc);
+          const selChanged = !oldState.selection.eq(newState.selection);
+          if (!docChanged && !selChanged) return null;
+
           const isExplicitToggle =
             !docChanged && transactions.some((tr) => tr.storedMarks !== null);
           if (isExplicitToggle) return null;


### PR DESCRIPTION
# Summary
After tiptap upgrade: #655 when adding a newline inside e.g. bolded text caused that in newline inline style was wrongly inactive.

This PR fixes that behaviour.

## Test Plan

1. Toggle bold
2. Type "Hello world"
3. Go with the cursor in the middle of typed text
4. press enter
5. Type "hello"

Bold should still be active and text in second line should be bolded.

## Screenshots / Videos
before:

https://github.com/user-attachments/assets/d246ba59-d824-4a01-a69e-48fe1e6ce812


after:

https://github.com/user-attachments/assets/8bfd455a-bac4-4c97-828d-bea32c224506


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |   ❌     |
| Web     |    ✅     |

## Checklist

- [X] E2E tests are passing
- [X] Required E2E tests have been added (if applicable)
