### PR TITLE
chore: xcode version bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.4'
+          xcode-version: '26.6'
 
       - name: Reset build folder and pods
         run: rm -rf apps/example/build apps/example/ios/Pods apps/example/ios/Podfile.lock


### PR DESCRIPTION
# Summary

In the CI workflow we had a pinned `xcode-version` to `16.4` which became not supported on the current macOS image. Bumped the `xcode-version` to `26.6` - latest version marked as `stable`
