### PR TITLE
fix: setMention on Android replacing surrounding text

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/textinput/styles/ParametrizedStyles.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/styles/ParametrizedStyles.kt
@@ -405,6 +405,8 @@ class ParametrizedStyles(
       val hasSpaceAtTheEnd = spannable.length > safeEnd && spannable[safeEnd] == ' '
       if (!hasSpaceAtTheEnd) {
         spannable.insert(safeEnd, " ")
+      } else {
+        Selection.setSelection(spannable, safeEnd + 1)
       }
     }
 

--- a/android/src/main/java/com/swmansion/enriched/textinput/styles/ParametrizedStyles.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/styles/ParametrizedStyles.kt
@@ -280,12 +280,16 @@ class ParametrizedStyles(
 
       // No previous word -> no mention to be detected
       if (previousWord == null) {
+        mentionStart = null
+        mentionEnd = null
         mentionHandler.endMention()
         return
       }
 
       // Previous word is not a mention -> end mention
       if (!mentionRegex.matches(previousWord.text)) {
+        mentionStart = null
+        mentionEnd = null
         mentionHandler.endMention()
         return
       }
@@ -314,6 +318,8 @@ class ParametrizedStyles(
       val spanEnd = spannable.getSpanEnd(span)
       val currentSpanText = spannable.subSequence(spanStart, spanEnd).toString()
       if (currentSpanText == span.getText()) {
+        mentionStart = null
+        mentionEnd = null
         mentionHandler.endMention()
         return
       }
@@ -393,8 +399,6 @@ class ParametrizedStyles(
     val end = mentionEnd ?: selectionEnd
 
     view.runAsATransaction {
-      Selection.setSelection(spannable, end)
-
       spannable.replace(start, end, text)
 
       val span = EnrichedInputMentionSpan(text, indicator, attributes, view.htmlStyle)
@@ -405,9 +409,8 @@ class ParametrizedStyles(
       val hasSpaceAtTheEnd = spannable.length > safeEnd && spannable[safeEnd] == ' '
       if (!hasSpaceAtTheEnd) {
         spannable.insert(safeEnd, " ")
-      } else {
-        Selection.setSelection(spannable, safeEnd + 1)
       }
+      Selection.setSelection(spannable, (safeEnd + 1).coerceAtMost(spannable.length))
     }
 
     view.mentionHandler?.reset()

--- a/android/src/main/java/com/swmansion/enriched/textinput/styles/ParametrizedStyles.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/styles/ParametrizedStyles.kt
@@ -1,6 +1,7 @@
 package com.swmansion.enriched.textinput.styles
 
 import android.text.Editable
+import android.text.Selection
 import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.Spanned
@@ -18,6 +19,7 @@ class ParametrizedStyles(
   private val view: EnrichedTextInputView,
 ) {
   private var mentionStart: Int? = null
+  private var mentionEnd: Int? = null
   private var isSettingLinkSpan = false
 
   var mentionIndicators: Array<String> = emptyArray<String>()
@@ -297,6 +299,9 @@ class ParametrizedStyles(
       indicator = mentionIndicatorRegex.find(currentWord.text)?.value ?: ""
     }
 
+    mentionStart = finalStart
+    mentionEnd = finalEnd
+
     // Mirror iOS conflicting-styles behaviour: check the full candidate range for
     // a finalized mention span. If the span's stored text still matches what is in
     // the buffer the mention is intact — block the event (covers HTML-loaded
@@ -314,6 +319,7 @@ class ParametrizedStyles(
       }
       spannable.removeSpan(span)
       mentionStart = spanStart
+      mentionEnd = spanEnd
     }
 
     // Extract text without indicator
@@ -322,6 +328,7 @@ class ParametrizedStyles(
     // Means we are starting mention
     if (text.isEmpty()) {
       mentionStart = finalStart
+      mentionEnd = finalEnd
     }
 
     mentionHandler.onMention(indicator, text)
@@ -383,9 +390,12 @@ class ParametrizedStyles(
     }
 
     val start = mentionStart ?: selectionStart
+    val end = mentionEnd ?: selectionEnd
 
     view.runAsATransaction {
-      spannable.replace(start, selectionEnd, text)
+      Selection.setSelection(spannable, end)
+
+      spannable.replace(start, end, text)
 
       val span = EnrichedInputMentionSpan(text, indicator, attributes, view.htmlStyle)
       val spanEnd = start + text.length
@@ -401,6 +411,7 @@ class ParametrizedStyles(
     view.mentionHandler?.reset()
     view.selection.validateStyles()
     mentionStart = null
+    mentionEnd = null
   }
 
   fun getStyleRange(): Pair<Int, Int> = view.selection?.getInlineSelection() ?: Pair(0, 0)


### PR DESCRIPTION
# Summary

When setting a mention, now it makes sure that:
- to replace the whole word with the created mention,
- to always move the cursor to the mention's trailing space

## Test Plan

Try setting a mention with the cursor in various places and experiment when there already are trailing spaces.

## Screenshots / Videos

Before:


https://github.com/user-attachments/assets/37fb805c-aaa1-4947-a8dd-4d1427ab1629



After:


https://github.com/user-attachments/assets/dfa3de9b-a8d4-410c-bbf1-0d028b0bab87



## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Web     |    ❌     |

## Checklist

- [x] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
