### PR TITLE
chore: `useHtmlNormalizer` enabled by default

### DIFF
--- a/apps/example-web/src/App.tsx
+++ b/apps/example-web/src/App.tsx
@@ -280,7 +280,6 @@ function App() {
           mentionIndicators={['@', '#']}
           htmlStyle={WEB_DEFAULT_HTML_STYLE}
           linkRegex={LINK_REGEX}
-          useHtmlNormalizer
         />
         <MentionPopup
           variant="user"

--- a/apps/example-web/src/components/TextRenderer.tsx
+++ b/apps/example-web/src/components/TextRenderer.tsx
@@ -30,7 +30,6 @@ export function TextRenderer({ htmlValue }: TextRendererProps) {
         ref={ref}
         style={enrichedTextStyle}
         htmlStyle={WEB_DEFAULT_HTML_STYLE}
-        useHtmlNormalizer
         onFocus={handleTextFocus}
         onBlur={handleTextBlur}
       >

--- a/apps/example/src/components/TextRenderer.tsx
+++ b/apps/example/src/components/TextRenderer.tsx
@@ -35,7 +35,6 @@ export const TextRenderer = ({ nodes }: TextRendererProps) => {
           htmlStyle={enrichedTextHtmlStyle}
           onLinkPress={handleLinkPress}
           onMentionPress={handleMentionPress}
-          useHtmlNormalizer
         >
           {node}
         </EnrichedText>

--- a/apps/example/src/screens/DevScreen.tsx
+++ b/apps/example/src/screens/DevScreen.tsx
@@ -73,7 +73,6 @@ export function DevScreen({ onSwitch }: DevScreenProps) {
               ANDROID_EXPERIMENTAL_SYNCHRONOUS_EVENTS
             }
             onPasteImages={(e) => editor.handlePasteImagesEvent(e.nativeEvent)}
-            useHtmlNormalizer
             testID="editor-input"
           />
           <Toolbar

--- a/apps/example/src/screens/EnrichedTextScreen.tsx
+++ b/apps/example/src/screens/EnrichedTextScreen.tsx
@@ -116,7 +116,6 @@ export function EnrichedTextScreen({ onSwitch }: EnrichedTextScreenProps) {
               ellipsizeMode={ellipsizeMode}
               onLinkPress={handleLinkPress}
               onMentionPress={handleMentionPress}
-              useHtmlNormalizer
             >
               {html}
             </EnrichedText>

--- a/apps/example/src/screens/TestScreen.tsx
+++ b/apps/example/src/screens/TestScreen.tsx
@@ -95,7 +95,6 @@ export function TestScreen({
               ANDROID_EXPERIMENTAL_SYNCHRONOUS_EVENTS
             }
             onPasteImages={(e) => editor.handlePasteImagesEvent(e.nativeEvent)}
-            useHtmlNormalizer
             testID="editor-input"
           />
           <Toolbar

--- a/docs/INPUT_API_REFERENCE.md
+++ b/docs/INPUT_API_REFERENCE.md
@@ -597,7 +597,7 @@ type TextShortcutStyle =
 - `trigger` is the typed pattern that activates the shortcut.
 - `style` is the style to apply when the trigger completes.
 
-**[Paragraph styles](../README.md#paragraph-tags)** fire at the start of a paragraph (e.g. `# ` → H1, `- ` → unordered list). Supported styles: `h1`–`h6`, `blockquote`, `codeblock`, `unordered_list`, `ordered_list`, `checkbox_list`.
+**[Paragraph styles](../README.md#paragraph-tags)** fire at the start of a paragraph (e.g. `#` → H1, `-` → unordered list). Supported styles: `h1`–`h6`, `blockquote`, `codeblock`, `unordered_list`, `ordered_list`, `checkbox_list`.
 
 > [!NOTE]
 > Paragraph shortcuts are only effective on plain paragraphs. If the paragraph already has an active paragraph style (e.g. it is already a heading or a list item), typing the trigger pattern has no effect.
@@ -639,13 +639,13 @@ If true, Android will use experimental synchronous events. This will prevent fro
 | ------ | ------------- | -------- |
 | `bool` | `false`       | Android  |
 
-### `useHtmlNormalizer` - EXPERIMENTAL
+### `useHtmlNormalizer`
 
-If true, external HTML pasted/inserted into the input (e.g. from Google Docs, Word, or web pages) will be normalized into the canonical tag subset that the enriched parser understands. However, this is an experimental feature, which has not been thoroughly tested. We may decide to enable it by default in a future release.
+If true, external HTML pasted/inserted into the input (e.g. from Google Docs, Word, or web pages) will be normalized into the canonical tag subset that the enriched parser understands.
 
 | Type   | Default Value | Platform          |
 | ------ | ------------- | ----------------- |
-| `bool` | `false`       | iOS, Android, Web |
+| `bool` | `true`        | iOS, Android, Web |
 
 ## Ref Methods
 

--- a/docs/INPUT_API_REFERENCE.md
+++ b/docs/INPUT_API_REFERENCE.md
@@ -597,7 +597,7 @@ type TextShortcutStyle =
 - `trigger` is the typed pattern that activates the shortcut.
 - `style` is the style to apply when the trigger completes.
 
-**[Paragraph styles](../README.md#paragraph-tags)** fire at the start of a paragraph (e.g. `#` → H1, `-` → unordered list). Supported styles: `h1`–`h6`, `blockquote`, `codeblock`, `unordered_list`, `ordered_list`, `checkbox_list`.
+**[Paragraph styles](../README.md#paragraph-tags)** fire at the start of a paragraph (e.g. `# ` → H1, `- ` → unordered list). Supported styles: `h1`–`h6`, `blockquote`, `codeblock`, `unordered_list`, `ordered_list`, `checkbox_list`.
 
 > [!NOTE]
 > Paragraph shortcuts are only effective on plain paragraphs. If the paragraph already has an active paragraph style (e.g. it is already a heading or a list item), typing the trigger pattern has no effect.

--- a/docs/TEXT_API_REFERENCE.md
+++ b/docs/TEXT_API_REFERENCE.md
@@ -42,7 +42,7 @@ If `true`, external HTML (e.g. from Google Docs, Word, web pages) will be normal
 
 | Type   | Default Value | Platform          |
 | ------ | ------------- | ----------------- |
-| `bool` | `false`       | iOS, Android, Web |
+| `bool` | `true`        | iOS, Android, Web |
 
 ### `ellipsizeMode`
 

--- a/src/native/EnrichedText.tsx
+++ b/src/native/EnrichedText.tsx
@@ -29,7 +29,7 @@ export const EnrichedText = ({
   children,
   style,
   htmlStyle: _htmlStyle = {},
-  useHtmlNormalizer = false,
+  useHtmlNormalizer = true,
   ellipsizeMode = 'tail',
   numberOfLines = 0,
   selectable = false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -758,7 +758,7 @@ export interface EnrichedTextInputProps extends Omit<ViewProps, 'children'> {
    * normalized through the HTML normalizer before being applied.
    * This converts arbitrary HTML into the canonical tag subset that the enriched
    * parser understands.
-   * Disabled by default.
+   * Enabled by default.
    */
   useHtmlNormalizer?: boolean;
 
@@ -800,7 +800,7 @@ export interface EnrichedTextProps extends ViewProps {
 
   /**
    * If true, external HTML will be normalized through the HTML normalizer
-   * before being rendered. Disabled by default.
+   * before being rendered. Enabled by default.
    */
   useHtmlNormalizer?: boolean;
 

--- a/src/utils/EnrichedTextInputDefaultProps.ts
+++ b/src/utils/EnrichedTextInputDefaultProps.ts
@@ -7,7 +7,7 @@ export const ENRICHED_TEXT_INPUT_DEFAULT_PROPS = {
   autoCapitalize: 'sentences',
   scrollEnabled: true,
   androidExperimentalSynchronousEvents: false,
-  useHtmlNormalizer: false,
+  useHtmlNormalizer: true,
   allowFontScaling: true,
   textShortcuts: [
     { trigger: '- ', style: 'unordered_list' },

--- a/src/web/EnrichedText.tsx
+++ b/src/web/EnrichedText.tsx
@@ -30,7 +30,7 @@ export const EnrichedText = memo(
     style,
     selectionColor,
     selectable = false,
-    useHtmlNormalizer = false,
+    useHtmlNormalizer = true,
     onFocus,
     onBlur,
   }: EnrichedTextProps) => {

--- a/src/web/EnrichedTextInput.tsx
+++ b/src/web/EnrichedTextInput.tsx
@@ -117,7 +117,7 @@ export const EnrichedTextInput = ({
   onEndMention,
   linkRegex,
   htmlStyle,
-  useHtmlNormalizer,
+  useHtmlNormalizer = ENRICHED_TEXT_INPUT_DEFAULT_PROPS.useHtmlNormalizer,
 }: EnrichedTextInputProps) => {
   const tiptapContent =
     defaultValue != null

--- a/src/web/normalization/htmlNormalizer.ts
+++ b/src/web/normalization/htmlNormalizer.ts
@@ -600,6 +600,8 @@ function walkNode(node: Node, out: { buf: string }): void {
 }
 
 export function normalizeHtml(html: string): string {
+  if (typeof DOMParser === 'undefined') return html;
+
   const parser = new DOMParser();
   const doc = parser.parseFromString(`<body>${html}</body>`, 'text/html');
   const body = doc.body;


### PR DESCRIPTION
# Summary

This PR makes `useHtmlNormalizer` enabled by default.

As it's an expected behaviour from our library to always try normalizing any outside HTML, we feel it's high time this prop became enabled from the get-go.

Also updated JSDocs, docs and example app components.

## Test Plan

-

## Screenshots / Videos

-

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web     |    ✅     |

## Checklist

- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
