### PR TITLE
fix: HTML parser handling img attributes with float values

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/common/parser/EnrichedParser.java
+++ b/android/src/main/java/com/swmansion/enriched/common/parser/EnrichedParser.java
@@ -856,7 +856,11 @@ class HtmlToSpannedConverter<T> implements ContentHandler {
   private static int parseDimension(String value) {
     if (value == null) return 0;
     try {
-      return (int) Math.floor(Float.parseFloat(value));
+      int parsed = (int) Math.floor(Float.parseFloat(value));
+      if (parsed < 0) {
+        return 0;
+      }
+      return parsed;
     } catch (NumberFormatException e) {
       return 0;
     }

--- a/android/src/main/java/com/swmansion/enriched/common/parser/EnrichedParser.java
+++ b/android/src/main/java/com/swmansion/enriched/common/parser/EnrichedParser.java
@@ -849,8 +849,17 @@ class HtmlToSpannedConverter<T> implements ContentHandler {
     int len = text.length();
     text.append("￼");
     Object imageSpan =
-        spanFactory.createImageSpan(src, Integer.parseInt(width), Integer.parseInt(height));
+        spanFactory.createImageSpan(src, parseDimension(width), parseDimension(height));
     text.setSpan(imageSpan, len, text.length(), EnrichedSpanFlags.forSpan(imageSpan));
+  }
+
+  private static int parseDimension(String value) {
+    if (value == null) return 0;
+    try {
+      return (int) Math.floor(Float.parseFloat(value));
+    } catch (NumberFormatException e) {
+      return 0;
+    }
   }
 
   private static void startA(Editable text, Attributes attributes) {

--- a/android/src/main/java/com/swmansion/enriched/common/parser/EnrichedParser.java
+++ b/android/src/main/java/com/swmansion/enriched/common/parser/EnrichedParser.java
@@ -857,10 +857,7 @@ class HtmlToSpannedConverter<T> implements ContentHandler {
     if (value == null) return 0;
     try {
       int parsed = (int) Math.floor(Float.parseFloat(value));
-      if (parsed < 0) {
-        return 0;
-      }
-      return parsed;
+      return Math.max(parsed, 0);
     } catch (NumberFormatException e) {
       return 0;
     }

--- a/ios/htmlParser/HtmlParser.mm
+++ b/ios/htmlParser/HtmlParser.mm
@@ -1327,8 +1327,9 @@
         ImageData *data = [imageStyle getImageDataAt:location];
         if (data != nullptr && data.uri != nullptr) {
           return [NSString
-              stringWithFormat:@"img src=\"%@\" width=\"%f\" height=\"%f\"",
-                               data.uri, data.width, data.height];
+              stringWithFormat:@"img src=\"%@\" width=\"%d\" height=\"%d\"",
+                               data.uri, (int)floor(data.width),
+                               (int)floor(data.height)];
         }
       }
       return @"img";


### PR DESCRIPTION
# Summary

HTML parser on Android explicitly tired to parse `<img>` dimension attributes `height` and `width` as `Integer`, with no exception caught, which caused the whole parser to bail. Web and iOS outputs HTML with float dimensions, so using that HTML in Android would break the input.

Also I got rid of the core cause of this issue - made the iOS parser function the same as the Android one and they both now converts both dimension attributes to integer values.  #688 

## Testing

Example HTML that would  break if used in `Set input's value`

```html
<html>
<p>Asd<img src="asd" width="30.000000" height="30.000000"/></p>
</html>
```

## Screenshots / Videos

iOS on the left, Android on the right

Before:

https://github.com/user-attachments/assets/acf3b65a-62c0-4e95-b97d-945115341b1a

After:

https://github.com/user-attachments/assets/306bba36-42b0-45ac-af18-706839c90ea0


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Web     |    ❌     |

## Checklist

- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
