### PR TITLE
fix(ios): convert img attributes to integer values

### DIFF
--- a/ios/htmlParser/HtmlParser.mm
+++ b/ios/htmlParser/HtmlParser.mm
@@ -1327,8 +1327,9 @@
         ImageData *data = [imageStyle getImageDataAt:location];
         if (data != nullptr && data.uri != nullptr) {
           return [NSString
-              stringWithFormat:@"img src=\"%@\" width=\"%f\" height=\"%f\"",
-                               data.uri, data.width, data.height];
+              stringWithFormat:@"img src=\"%@\" width=\"%d\" height=\"%d\"",
+                               data.uri, (int)floor(data.width),
+                               (int)floor(data.height)];
         }
       }
       return @"img";


### PR DESCRIPTION
# Summary

Now the `img` attributes are converted to integer. It's truthful to official HTML5 specifications, where `width` and `height` should be integer values and the floating point in HTML could be destructive, which could produce a similar issue as in 
https://github.com/software-mansion/react-native-enriched-html/pull/685

## Screenshots

When adding an image via modal with `height` and `width` set to `30`

Before:

<img width="341" height="331" alt="image" src="https://github.com/user-attachments/assets/f905c3c9-7f6e-4bb7-86ec-235e9668c37c" />

After:

<img width="334" height="326" alt="image" src="https://github.com/user-attachments/assets/2c1dae24-693a-4c9a-84cf-418865837a7e" />


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Web     |    ❌     |

## Checklist

- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
