### PR TITLE
fix: improve internal skills gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,4 +93,4 @@ nitrogen/
 .maestro/**/*_diff.png
 
 # Claude skills
-.claude/skills/internal
+.claude/skills/*-internal.md


### PR DESCRIPTION
Turns out skills must be in the top-level `skills` directory to be registred by claude, so I changed the gitignore to only ignore ones ending in `-internal.md`.