### PR TITLE
fix(android): enriched text initial height measure

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/text/MeasurementStore.kt
+++ b/android/src/main/java/com/swmansion/enriched/text/MeasurementStore.kt
@@ -17,6 +17,7 @@ import com.facebook.react.views.text.ReactTypefaceUtils.parseFontWeight
 import com.facebook.yoga.YogaMeasureMode
 import com.facebook.yoga.YogaMeasureOutput
 import com.swmansion.enriched.common.EnrichedConstants
+import com.swmansion.enriched.common.GumboNormalizer
 import com.swmansion.enriched.common.allowFontScalingFromProps
 import com.swmansion.enriched.common.parser.EnrichedParser
 import com.swmansion.enriched.common.pixelFromSpOrDp
@@ -104,21 +105,74 @@ object MeasurementStore {
     props: ReadableMap?,
   ): CharSequence {
     val text = props?.getString("text") ?: ""
+    val enrichedStyle = getEnrichedStyle(context, fontSize, props)
+    val useHtmlNormalizer = useHtmlNormalizerFromProps(props)
 
-    val isHtml = text.startsWith("<html>") && text.endsWith("</html>")
-    if (!isHtml) return text
+    return parseText(text, enrichedStyle, useHtmlNormalizer) ?: text
+  }
 
-    try {
-      val style = props?.getMap("htmlStyle") ?: return text
-      val allowFontScaling = allowFontScalingFromProps(props)
-      val enrichedStyle =
-        EnrichedTextStyle.fromReadableMap(context as ReactContext, fontSize, style, allowFontScaling)
+  private fun getEnrichedStyle(
+    context: Context,
+    fontSize: Int,
+    props: ReadableMap?,
+  ): EnrichedTextStyle? {
+    val style = props?.getMap("htmlStyle") ?: return null
+    val allowFontScaling = allowFontScalingFromProps(props)
+    return EnrichedTextStyle.fromReadableMap(context as ReactContext, fontSize, style, allowFontScaling)
+  }
+
+  private fun useHtmlNormalizerFromProps(props: ReadableMap?): Boolean {
+    if (props == null || !props.hasKey("useHtmlNormalizer") || props.isNull("useHtmlNormalizer")) {
+      return false
+    }
+    return props.getBoolean("useHtmlNormalizer")
+  }
+
+  private fun parseText(
+    text: String,
+    style: EnrichedTextStyle?,
+    useHtmlNormalizer: Boolean,
+  ): CharSequence? {
+    if (style == null) return null
+
+    val isInternalHtml = text.startsWith("<html>") && text.endsWith("</html>")
+
+    if (isInternalHtml) {
+      try {
+        val factory = EnrichedTextSpanFactory()
+        val parsed = EnrichedParser.fromHtml(text, style, factory)
+        return parsed.trimEnd('\n')
+      } catch (e: Exception) {
+        Log.w("MeasurementStore", "Error parsing initial HTML text: ${e.message}")
+        return normalizeHtmlIfNeeded(text, style, useHtmlNormalizer)
+      }
+    }
+
+    return normalizeHtmlIfNeeded(text, style, useHtmlNormalizer)
+  }
+
+  private fun normalizeHtmlIfNeeded(
+    text: String,
+    style: EnrichedTextStyle,
+    useHtmlNormalizer: Boolean,
+  ): CharSequence? {
+    if (!useHtmlNormalizer) return null
+    return parseNormalizedHtml(text, style)
+  }
+
+  private fun parseNormalizedHtml(
+    text: String,
+    style: EnrichedTextStyle,
+  ): CharSequence? {
+    val normalized = GumboNormalizer.normalizeHtml(text) ?: return null
+
+    return try {
       val factory = EnrichedTextSpanFactory()
-      val parsed = EnrichedParser.fromHtml(text, enrichedStyle, factory)
-      return parsed.trimEnd('\n')
+      val parsed = EnrichedParser.fromHtml(normalized, style, factory)
+      parsed.trimEnd('\n')
     } catch (e: Exception) {
-      Log.w("MeasurementStore", "Error parsing initial HTML text: ${e.message}")
-      return text
+      Log.w("MeasurementStore", "Error parsing normalized HTML: ${e.message}")
+      null
     }
   }
 

--- a/android/src/main/java/com/swmansion/enriched/text/MeasurementStore.kt
+++ b/android/src/main/java/com/swmansion/enriched/text/MeasurementStore.kt
@@ -140,44 +140,22 @@ object MeasurementStore {
     useHtmlNormalizer: Boolean,
     isInternalHtml: Boolean,
   ): CharSequence? {
-    if (isInternalHtml) {
-      try {
-        val factory = EnrichedTextSpanFactory()
-        val parsed = EnrichedParser.fromHtml(text, style, factory)
-        return parsed.trimEnd('\n')
-      } catch (e: Exception) {
-        Log.w("MeasurementStore", "Error parsing initial HTML text: ${e.message}")
-        return normalizeHtmlIfNeeded(text, style, useHtmlNormalizer)
-      }
-    }
+    val textToParse = if (isInternalHtml) text else normalizeHtmlIfNeeded(text, useHtmlNormalizer)
 
-    return normalizeHtmlIfNeeded(text, style, useHtmlNormalizer)
+    try {
+      val factory = EnrichedTextSpanFactory()
+      val parsed = EnrichedParser.fromHtml(textToParse, style, factory)
+      return parsed.trimEnd('\n')
+    } catch (e: Exception) {
+      Log.w("MeasurementStore", "Error parsing initial HTML text: ${e.message}")
+      return textToParse
+    }
   }
 
   private fun normalizeHtmlIfNeeded(
     text: String,
-    style: EnrichedTextStyle,
     useHtmlNormalizer: Boolean,
-  ): CharSequence? {
-    if (!useHtmlNormalizer) return null
-    return parseNormalizedHtml(text, style)
-  }
-
-  private fun parseNormalizedHtml(
-    text: String,
-    style: EnrichedTextStyle,
-  ): CharSequence? {
-    val normalized = GumboNormalizer.normalizeHtml(text) ?: return null
-
-    return try {
-      val factory = EnrichedTextSpanFactory()
-      val parsed = EnrichedParser.fromHtml(normalized, style, factory)
-      parsed.trimEnd('\n')
-    } catch (e: Exception) {
-      Log.w("MeasurementStore", "Error parsing normalized HTML: ${e.message}")
-      null
-    }
-  }
+  ): String? = if (useHtmlNormalizer) GumboNormalizer.normalizeHtml(text) else null
 
   private fun getInitialFontSize(props: ReadableMap?): Float {
     val propsFontSize = props?.getDouble("fontSize")?.toFloat() ?: EnrichedConstants.TEXT_DEFAULT_FONT_SIZE

--- a/android/src/main/java/com/swmansion/enriched/text/MeasurementStore.kt
+++ b/android/src/main/java/com/swmansion/enriched/text/MeasurementStore.kt
@@ -112,19 +112,19 @@ object MeasurementStore {
       return text
     }
 
-    val enrichedStyle = getEnrichedStyle(context, fontSize, props) ?: return text
+    try {
+      val textToParse = if (isInternalHtml) text else GumboNormalizer.normalizeHtml(text)
+      val style = props?.getMap("htmlStyle") ?: return text
+      val allowFontScaling = allowFontScalingFromProps(props)
+      val enrichedStyle = EnrichedTextStyle.fromReadableMap(context as ReactContext, fontSize, style, allowFontScaling)
 
-    return parseText(text, enrichedStyle, useHtmlNormalizer, isInternalHtml) ?: text
-  }
-
-  private fun getEnrichedStyle(
-    context: Context,
-    fontSize: Int,
-    props: ReadableMap?,
-  ): EnrichedTextStyle? {
-    val style = props?.getMap("htmlStyle") ?: return null
-    val allowFontScaling = allowFontScalingFromProps(props)
-    return EnrichedTextStyle.fromReadableMap(context as ReactContext, fontSize, style, allowFontScaling)
+      val factory = EnrichedTextSpanFactory()
+      val parsed = EnrichedParser.fromHtml(textToParse, enrichedStyle, factory)
+      return parsed.trimEnd('\n')
+    } catch (e: Exception) {
+      Log.w("MeasurementStore", "Error parsing initial HTML text: ${e.message}")
+      return text
+    }
   }
 
   private fun useHtmlNormalizerFromProps(props: ReadableMap?): Boolean {
@@ -133,29 +133,6 @@ object MeasurementStore {
     }
     return props.getBoolean("useHtmlNormalizer")
   }
-
-  private fun parseText(
-    text: String,
-    style: EnrichedTextStyle,
-    useHtmlNormalizer: Boolean,
-    isInternalHtml: Boolean,
-  ): CharSequence? {
-    val textToParse = if (isInternalHtml) text else normalizeHtmlIfNeeded(text, useHtmlNormalizer)
-
-    try {
-      val factory = EnrichedTextSpanFactory()
-      val parsed = EnrichedParser.fromHtml(textToParse, style, factory)
-      return parsed.trimEnd('\n')
-    } catch (e: Exception) {
-      Log.w("MeasurementStore", "Error parsing initial HTML text: ${e.message}")
-      return textToParse
-    }
-  }
-
-  private fun normalizeHtmlIfNeeded(
-    text: String,
-    useHtmlNormalizer: Boolean,
-  ): String? = if (useHtmlNormalizer) GumboNormalizer.normalizeHtml(text) else null
 
   private fun getInitialFontSize(props: ReadableMap?): Float {
     val propsFontSize = props?.getDouble("fontSize")?.toFloat() ?: EnrichedConstants.TEXT_DEFAULT_FONT_SIZE

--- a/android/src/main/java/com/swmansion/enriched/text/MeasurementStore.kt
+++ b/android/src/main/java/com/swmansion/enriched/text/MeasurementStore.kt
@@ -105,10 +105,16 @@ object MeasurementStore {
     props: ReadableMap?,
   ): CharSequence {
     val text = props?.getString("text") ?: ""
-    val enrichedStyle = getEnrichedStyle(context, fontSize, props)
+    val isInternalHtml = text.startsWith("<html>") && text.endsWith("</html>")
     val useHtmlNormalizer = useHtmlNormalizerFromProps(props)
 
-    return parseText(text, enrichedStyle, useHtmlNormalizer) ?: text
+    if (!isInternalHtml && !useHtmlNormalizer) {
+      return text
+    }
+
+    val enrichedStyle = getEnrichedStyle(context, fontSize, props) ?: return text
+
+    return parseText(text, enrichedStyle, useHtmlNormalizer, isInternalHtml) ?: text
   }
 
   private fun getEnrichedStyle(
@@ -130,13 +136,10 @@ object MeasurementStore {
 
   private fun parseText(
     text: String,
-    style: EnrichedTextStyle?,
+    style: EnrichedTextStyle,
     useHtmlNormalizer: Boolean,
+    isInternalHtml: Boolean,
   ): CharSequence? {
-    if (style == null) return null
-
-    val isInternalHtml = text.startsWith("<html>") && text.endsWith("</html>")
-
     if (isInternalHtml) {
       try {
         val factory = EnrichedTextSpanFactory()

--- a/android/src/main/new_arch/react/renderer/components/ReactNativeEnrichedSpec/conversions.h
+++ b/android/src/main/new_arch/react/renderer/components/ReactNativeEnrichedSpec/conversions.h
@@ -19,6 +19,7 @@ inline folly::dynamic toDynamic(const EnrichedTextInputViewProps &props) {
   serializedProps["fontFamily"] = props.fontFamily;
   serializedProps["lineHeight"] = props.lineHeight;
   serializedProps["allowFontScaling"] = props.allowFontScaling;
+  serializedProps["useHtmlNormalizer"] = props.useHtmlNormalizer;
   serializedProps["htmlStyle"] = toDynamic(props.htmlStyle);
 
   return serializedProps;
@@ -36,6 +37,7 @@ inline folly::dynamic toDynamic(const EnrichedTextViewProps &props) {
   serializedProps["numberOfLines"] = props.numberOfLines;
   serializedProps["ellipsizeMode"] = props.ellipsizeMode;
   serializedProps["allowFontScaling"] = props.allowFontScaling;
+  serializedProps["useHtmlNormalizer"] = props.useHtmlNormalizer;
   serializedProps["htmlStyle"] = toDynamic(props.htmlStyle);
 
   return serializedProps;


### PR DESCRIPTION
# Summary
Fixes: #700 

## Test Plan

Run reproduction steps from issue: #700
EnrichedText height should be measured properly.

## Screenshots / Videos


https://github.com/user-attachments/assets/5cf47a83-320b-4542-9714-bc8ab1054c8b


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Web     |    ❌     |

## Checklist

- [x] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
