### PR TITLE
feat: default autofocus prop value to false 

### DIFF
--- a/src/native/EnrichedTextInput.tsx
+++ b/src/native/EnrichedTextInput.tsx
@@ -48,7 +48,7 @@ type HtmlRequest = {
 
 export const EnrichedTextInput = ({
   ref,
-  autoFocus,
+  autoFocus = false,
   editable = ENRICHED_TEXT_INPUT_DEFAULT_PROPS.editable,
   mentionIndicators = ENRICHED_TEXT_INPUT_DEFAULT_PROPS.mentionIndicators.slice(),
   defaultValue,

--- a/src/web/EnrichedTextInput.tsx
+++ b/src/web/EnrichedTextInput.tsx
@@ -91,7 +91,7 @@ function runFocused(
 export const EnrichedTextInput = ({
   ref,
   defaultValue,
-  autoFocus,
+  autoFocus = false,
   editable = ENRICHED_TEXT_INPUT_DEFAULT_PROPS.editable,
   placeholder = '',
   placeholderTextColor,


### PR DESCRIPTION
# Summary

On web when `autoFocus` prop was not provided in `EnrichedTextInput` - it was `undefined`, Tiptap would default to the enabled autofocus, which we don't want.

Now the `autoFocus` prop defaults to `false` if not provided. 

Added the same default value in the native `EnrichedTextInput` component for consistency. That change does practically nothing, as earlier it also defaulted to a disabled auto-focus if not provided, but it was handled on the native side - now it happens earlier in JS.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web     |    ✅     |

## Checklist

- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
