### PR TITLE
fix(web): headings font color inheritance

### DIFF
--- a/src/web/EnrichedText.css
+++ b/src/web/EnrichedText.css
@@ -47,6 +47,7 @@
   font-weight: var(--et-h1-font-weight);
   margin: 0;
   line-height: normal;
+  color: inherit;
 }
 .eti-editor h2,
 .et-view h2 {
@@ -54,6 +55,7 @@
   font-weight: var(--et-h2-font-weight);
   margin: 0;
   line-height: normal;
+  color: inherit;
 }
 .eti-editor h3,
 .et-view h3 {
@@ -61,6 +63,7 @@
   font-weight: var(--et-h3-font-weight);
   margin: 0;
   line-height: normal;
+  color: inherit;
 }
 .eti-editor h4,
 .et-view h4 {
@@ -68,6 +71,7 @@
   font-weight: var(--et-h4-font-weight);
   margin: 0;
   line-height: normal;
+  color: inherit;
 }
 .eti-editor h5,
 .et-view h5 {
@@ -75,6 +79,7 @@
   font-weight: var(--et-h5-font-weight);
   margin: 0;
   line-height: normal;
+  color: inherit;
 }
 .eti-editor h6,
 .et-view h6 {
@@ -82,6 +87,7 @@
   font-weight: var(--et-h6-font-weight);
   margin: 0;
   line-height: normal;
+  color: inherit;
 }
 
 .eti-editor blockquote,


### PR DESCRIPTION
# Summary

The color of the headings - `h1`, `h2`, ..., was not properly defined. You could create a CSS rule e.g `h1 { color: 'white' }` in an app's higher context and that color would get applied, it did not use the editor's `color`. Now it properly inherits it.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |
| Web     |    ✅     |

## Checklist

- [x] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
