### PR TITLE
chore: update homepage url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "bugs": {
     "url": "https://github.com/software-mansion/react-native-enriched-html/issues"
   },
-  "homepage": "https://github.com/software-mansion/react-native-enriched-html#readme",
+  "homepage": "https://enriched.swmansion.com/html",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },


### PR DESCRIPTION
Updates the `homepage` field in package.json to point to the docs site instead of the GitHub README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)