### PR TITLE
docs: htmlStyle for interactive examples components

### DIFF
--- a/docs/docs/fundamentals/your-first-editor.mdx
+++ b/docs/docs/fundamentals/your-first-editor.mdx
@@ -204,4 +204,13 @@ Here's that editor running live on this page. Select some text and hit **Bold** 
 notice the button turns green whenever the cursor sits on bold text. Switch to
 the **Code** tab to see the exact source.
 
+:::note
+
+The `htmlStyle` you'll spot in the Code tab is only there to make the rendered
+text match these docs' color palette, so
+don't worry about it here. If want to learn more, see
+[Styling the input](/core-functionalities/styling-the-input).
+
+:::
+
 <InteractiveExample src={FirstEditorSrc} component={FirstEditor} />

--- a/docs/docs/fundamentals/your-first-editor.mdx
+++ b/docs/docs/fundamentals/your-first-editor.mdx
@@ -204,13 +204,4 @@ Here's that editor running live on this page. Select some text and hit **Bold** 
 notice the button turns green whenever the cursor sits on bold text. Switch to
 the **Code** tab to see the exact source.
 
-:::note
-
-The `htmlStyle` you'll spot in the Code tab is only there to make the rendered
-text match these docs' color palette, so
-don't worry about it here. If you want to learn more, see
-[Styling the input](/core-functionalities/styling-the-input).
-
-:::
-
 <InteractiveExample src={FirstEditorSrc} component={FirstEditor} />

--- a/docs/docs/fundamentals/your-first-editor.mdx
+++ b/docs/docs/fundamentals/your-first-editor.mdx
@@ -208,7 +208,7 @@ the **Code** tab to see the exact source.
 
 The `htmlStyle` you'll spot in the Code tab is only there to make the rendered
 text match these docs' color palette, so
-don't worry about it here. If want to learn more, see
+don't worry about it here. If you want to learn more, see
 [Styling the input](/core-functionalities/styling-the-input).
 
 :::

--- a/docs/src/css/typography.css
+++ b/docs/src/css/typography.css
@@ -171,6 +171,10 @@ code {
   border-bottom: 1px solid currentColor;
 }
 
+.eti-editor a {
+  border-bottom: none;
+}
+
 /* Sidebar */
 [class*='menu__list-item-collapsible'] a {
   font-family: var(--swm-title-font);

--- a/docs/src/examples/BasicStylesEditor.tsx
+++ b/docs/src/examples/BasicStylesEditor.tsx
@@ -5,6 +5,7 @@ import type {
 } from 'react-native-enriched-html';
 import { useRef, useState } from 'react';
 import { View, StyleSheet, Pressable, Text } from 'react-native';
+import { htmlStyle } from './htmlStyle';
 
 export default function App() {
   const ref = useRef<EnrichedTextInputInstance>(null);
@@ -73,6 +74,7 @@ export default function App() {
       <EnrichedTextInput
         ref={ref}
         style={styles.input}
+        htmlStyle={htmlStyle}
         placeholder="Type something here..."
         onChangeState={e => setState(e.nativeEvent)}
       />

--- a/docs/src/examples/FirstEditor.tsx
+++ b/docs/src/examples/FirstEditor.tsx
@@ -5,6 +5,7 @@ import type {
 } from 'react-native-enriched-html';
 import { useRef, useState } from 'react';
 import { View, StyleSheet, Pressable, Text } from 'react-native';
+import { htmlStyle } from './htmlStyle';
 
 export default function App() {
   const ref = useRef<EnrichedTextInputInstance>(null);
@@ -15,6 +16,7 @@ export default function App() {
       <EnrichedTextInput
         ref={ref}
         style={styles.input}
+        htmlStyle={htmlStyle}
         placeholder="Type something here..."
         onChangeState={e => setState(e.nativeEvent)}
       />

--- a/docs/src/examples/FirstEditor.tsx
+++ b/docs/src/examples/FirstEditor.tsx
@@ -16,6 +16,10 @@ export default function App() {
       <EnrichedTextInput
         ref={ref}
         style={styles.input}
+        // The `htmlStyle` here is only there to make the rendered
+        // input match these docs' color palette, so don't worry
+        // about it here. If you want to learn more, see the
+        // "Styling the input" section.
         htmlStyle={htmlStyle}
         placeholder="Type something here..."
         onChangeState={e => setState(e.nativeEvent)}

--- a/docs/src/examples/ImagesEditor.tsx
+++ b/docs/src/examples/ImagesEditor.tsx
@@ -2,6 +2,7 @@ import { EnrichedTextInput } from 'react-native-enriched-html';
 import type { EnrichedTextInputInstance } from 'react-native-enriched-html';
 import { useRef } from 'react';
 import { View, StyleSheet, Pressable, Text } from 'react-native';
+import { htmlStyle } from './htmlStyle';
 
 export default function App() {
   const ref = useRef<EnrichedTextInputInstance>(null);
@@ -23,6 +24,7 @@ export default function App() {
       <EnrichedTextInput
         ref={ref}
         style={styles.input}
+        htmlStyle={htmlStyle}
         placeholder="Place the cursor, then insert an image below..."
       />
       <View style={styles.row}>

--- a/docs/src/examples/LinksEditor.tsx
+++ b/docs/src/examples/LinksEditor.tsx
@@ -5,6 +5,7 @@ import type {
 } from 'react-native-enriched-html';
 import { useRef, useState } from 'react';
 import { View, StyleSheet, Pressable, Text } from 'react-native';
+import { htmlStyle } from './htmlStyle';
 
 // Detect "enriched://" URLs as links.
 const linkRegex = /enriched:\/\/\S+/g;
@@ -33,6 +34,7 @@ export default function App() {
       <EnrichedTextInput
         ref={ref}
         style={styles.input}
+        htmlStyle={htmlStyle}
         placeholder="Type enriched://home, or select text below..."
         linkRegex={linkRegex}
         onChangeSelection={e => setSelection(e.nativeEvent)}

--- a/docs/src/examples/ListsEditor.tsx
+++ b/docs/src/examples/ListsEditor.tsx
@@ -5,6 +5,7 @@ import type {
 } from 'react-native-enriched-html';
 import { useRef, useState } from 'react';
 import { View, StyleSheet, Pressable, Text } from 'react-native';
+import { htmlStyle } from './htmlStyle';
 
 export default function App() {
   const ref = useRef<EnrichedTextInputInstance>(null);
@@ -52,6 +53,7 @@ export default function App() {
       <EnrichedTextInput
         ref={ref}
         style={styles.input}
+        htmlStyle={htmlStyle}
         placeholder="Type a few lines, then turn them into a list..."
         onChangeState={e => setState(e.nativeEvent)}
       />

--- a/docs/src/examples/MentionEditor.tsx
+++ b/docs/src/examples/MentionEditor.tsx
@@ -2,6 +2,7 @@ import { EnrichedTextInput } from 'react-native-enriched-html';
 import type { EnrichedTextInputInstance } from 'react-native-enriched-html';
 import { useRef } from 'react';
 import { View, StyleSheet, Pressable, Text } from 'react-native';
+import { htmlStyle } from './htmlStyle';
 
 const user = { id: '1', name: 'John' };
 
@@ -18,6 +19,7 @@ export default function App() {
       <EnrichedTextInput
         ref={ref}
         style={styles.input}
+        htmlStyle={htmlStyle}
         placeholder="Type '@', then tap the button below..."
       />
       <Pressable style={styles.button} onPress={insertMention}>

--- a/docs/src/examples/RenderingEditor.tsx
+++ b/docs/src/examples/RenderingEditor.tsx
@@ -5,6 +5,7 @@ import type {
 } from 'react-native-enriched-html';
 import { useRef, useState } from 'react';
 import { View, StyleSheet, Pressable, Text } from 'react-native';
+import { htmlStyle, enrichedTextHtmlStyle } from './htmlStyle';
 
 export default function App() {
   const ref = useRef<EnrichedTextInputInstance>(null);
@@ -43,6 +44,7 @@ export default function App() {
       <EnrichedTextInput
         ref={ref}
         style={styles.input}
+        htmlStyle={htmlStyle}
         placeholder="Type something here..."
         onChangeState={e => setState(e.nativeEvent)}
       />
@@ -74,7 +76,10 @@ export default function App() {
         </Pressable>
       </View>
 
-      <EnrichedText style={styles.viewer} selectable>
+      <EnrichedText
+        style={styles.viewer}
+        htmlStyle={enrichedTextHtmlStyle}
+        selectable>
         {html}
       </EnrichedText>
     </View>

--- a/docs/src/examples/TextAlignmentEditor.tsx
+++ b/docs/src/examples/TextAlignmentEditor.tsx
@@ -5,6 +5,7 @@ import type {
 } from 'react-native-enriched-html';
 import { useRef, useState } from 'react';
 import { View, StyleSheet, Pressable, Text } from 'react-native';
+import { htmlStyle } from './htmlStyle';
 
 const alignments = ['left', 'center', 'right', 'justify'] as const;
 
@@ -32,6 +33,7 @@ export default function App() {
       <EnrichedTextInput
         ref={ref}
         style={styles.input}
+        htmlStyle={htmlStyle}
         placeholder="Type a paragraph, then align it below..."
         onChangeState={e => setState(e.nativeEvent)}
       />

--- a/docs/src/examples/TextShortcutsEditor.tsx
+++ b/docs/src/examples/TextShortcutsEditor.tsx
@@ -2,6 +2,7 @@ import { EnrichedTextInput } from 'react-native-enriched-html';
 import type { EnrichedTextInputInstance } from 'react-native-enriched-html';
 import { useRef } from 'react';
 import { View, StyleSheet } from 'react-native';
+import { htmlStyle } from './htmlStyle';
 
 export default function App() {
   const ref = useRef<EnrichedTextInputInstance>(null);
@@ -11,6 +12,7 @@ export default function App() {
       <EnrichedTextInput
         ref={ref}
         style={styles.input}
+        htmlStyle={htmlStyle}
         // Two shortcuts, one of each kind:
         // - '# ' at the start of a paragraph turns the line into an H1 (paragraph style)
         // - '**text**' wraps the delimited text in bold (inline style)

--- a/docs/src/examples/htmlStyle.ts
+++ b/docs/src/examples/htmlStyle.ts
@@ -1,0 +1,78 @@
+import type {
+  HtmlStyle,
+  EnrichedTextHtmlStyle,
+} from 'react-native-enriched-html';
+
+// Shared htmlStyle for the interactive docs examples.
+//
+// The colors are tuned to read well in Docusaurus' light and dark modes. They
+// exist purely to make the rendered rich text match the docs' visual language
+//
+// It lives in its own file so the example sources stay focused on the API
+// being demonstrated.
+
+const TEXT = '#232736'; // body text inside code blocks
+const MUTED = '#5b6bb0'; // list markers, quote text
+const GREEN = '#57b495'; // checkboxes
+const LINK = '#2f6fd0'; // link / mention accent
+
+export const htmlStyle: HtmlStyle = {
+  h1: { fontSize: 30, bold: true },
+  h2: { fontSize: 26, bold: true },
+  h3: { fontSize: 22, bold: true },
+  h4: { fontSize: 19, bold: true },
+  h5: { fontSize: 17, bold: true },
+  h6: { fontSize: 15, bold: true },
+  blockquote: {
+    borderColor: '#919fcf',
+    borderWidth: 4,
+    gapWidth: 12,
+    color: MUTED,
+  },
+  codeblock: {
+    color: TEXT,
+    backgroundColor: '#e2e5ff',
+    borderRadius: 8,
+  },
+  code: {
+    color: '#782aeb',
+    backgroundColor: '#e8dafc',
+  },
+  a: {
+    color: '#38acdd',
+    textDecorationLine: 'none',
+  },
+  mention: {
+    color: LINK,
+    backgroundColor: '#dbe7fb',
+    textDecorationLine: 'none',
+  },
+  ol: {
+    gapWidth: 8,
+    markerFontWeight: '600',
+    markerColor: MUTED,
+  },
+  ul: {
+    bulletColor: MUTED,
+    bulletSize: 5,
+    marginLeft: 4,
+    gapWidth: 8,
+  },
+  ulCheckbox: {
+    boxSize: 16,
+    boxColor: GREEN,
+  },
+};
+
+export const enrichedTextHtmlStyle: EnrichedTextHtmlStyle = {
+  ...htmlStyle,
+  a: {
+    ...htmlStyle.a,
+    pressColor: '#3b82f6',
+  },
+  mention: {
+    ...(htmlStyle.mention as object),
+    pressColor: '#1d4fa0',
+    pressBackgroundColor: '#c2d8f7',
+  },
+};

--- a/docs/src/examples/htmlStyle.ts
+++ b/docs/src/examples/htmlStyle.ts
@@ -40,7 +40,7 @@ export const htmlStyle: HtmlStyle = {
   },
   a: {
     color: '#38acdd',
-    textDecorationLine: 'none',
+    textDecorationLine: 'underline',
   },
   mention: {
     color: LINK,

--- a/docs/src/examples/htmlStyle.ts
+++ b/docs/src/examples/htmlStyle.ts
@@ -71,7 +71,7 @@ export const enrichedTextHtmlStyle: EnrichedTextHtmlStyle = {
     pressColor: '#3b82f6',
   },
   mention: {
-    ...(htmlStyle.mention as object),
+    ...htmlStyle.mention,
     pressColor: '#1d4fa0',
     pressBackgroundColor: '#c2d8f7',
   },


### PR DESCRIPTION
# Summary

Provided an `htmlStyle` for the `EnrichedTextInput` and `EnrichedText` components in the interactive examples. The internal default values didn't look too well, so this `htmlStyle` provides colorings that match the docs' style both in dark and light mode.

That makes the interactive examples' code not directly copiable, as `htmlStyle` is not present there to reduce noise. Added a note explaining that in the `your-first-editor` section.