### PR TITLE
fix: normalizer does not strip br nodes inside blockquote

### DIFF
--- a/cpp/parser/GumboNormalizer.c
+++ b/cpp/parser/GumboNormalizer.c
@@ -598,7 +598,11 @@ static void flatten_bq_node(GumboNode *node, buffer_t *ib, buffer_t *out) {
     return;
   }
   if (is_br_node(node)) {
-    flush_inline_p(ib, out, NULL);
+    // Emit the canonical <br> so it is not silently dropped.
+    // With buffered inline content it just terminates the current paragraph.
+    if (!flush_inline_p(ib, out, NULL)) {
+      buffer_append_str(out, "<br>");
+    }
     return;
   }
   if (is_block_producing(node) || is_blockquote_node(node)) {

--- a/cpp/tests/GumboParserTest.cpp
+++ b/cpp/tests/GumboParserTest.cpp
@@ -401,7 +401,7 @@ TEST(GumboParserTest, DivRemappings) {
           "</b>hello<div><br></div><div>hi</div></li></ul></div></div></"
           "blockquote></span>"),
       "<p>what do you think of this craziness</p><blockquote><p><b>another one "
-      "</b>hello</p><p>hi</p></blockquote>");
+      "</b>hello</p><br><p>hi</p></blockquote>");
 }
 
 TEST(GumboParserTest, ListFlattening) {
@@ -508,6 +508,13 @@ TEST(GumboParserTest, BrRemappings) {
                 "href='https://google.com'>Net</a></p>"),
             "<p><b>Asdasdasd</b></p><br><br><p>Sent with <a "
             "href=\"https://google.com\">Net</a></p>");
+  // A <br> between blockquote paragraphs is preserved.
+  EXPECT_EQ(
+      GumboParser::normalizeHtml(
+          "<blockquote><p>this is a pretty short blockquote.</p><br><p>This is "
+          "a line after an empty line.</p></blockquote>"),
+      "<blockquote><p>this is a pretty short blockquote.</p><br><p>This is a "
+      "line after an empty line.</p></blockquote>");
 }
 
 // Preserve text alignment
@@ -581,9 +588,10 @@ TEST(GumboParserTest, InterBlockWhitespace) {
   EXPECT_EQ(GumboParser::normalizeHtml(
                 "<p>Asdasd</p>\n\n<p>Asdasd</p>\n\n<p>Asdasda</p>"),
             "<p>Asdasd</p><p>Asdasd</p><p>Asdasda</p>");
-  EXPECT_EQ(GumboParser::normalizeHtml(
-                "<html>\n<p>Asdasd</p>\n<p>Asdasd</p>\n<p>Asdasda</p>\n</html>"),
-            "<p>Asdasd</p><p>Asdasd</p><p>Asdasda</p>");
+  EXPECT_EQ(
+      GumboParser::normalizeHtml(
+          "<html>\n<p>Asdasd</p>\n<p>Asdasd</p>\n<p>Asdasda</p>\n</html>"),
+      "<p>Asdasd</p><p>Asdasd</p><p>Asdasda</p>");
   EXPECT_EQ(GumboParser::normalizeHtml("<p>Asdasd</p> <p>Asdasd</p>"),
             "<p>Asdasd</p><p>Asdasd</p>");
 

--- a/src/web/__tests__/htmlNormalizer.test.ts
+++ b/src/web/__tests__/htmlNormalizer.test.ts
@@ -359,7 +359,7 @@ describe('htmlNormalizer', () => {
       ],
       [
         '<div>what do you think of this craziness</div><span><blockquote><div><div><ul><li><b>another one </b>hello<div><br></div><div>hi</div></li></ul></div></div></blockquote></span>',
-        '<p>what do you think of this craziness</p><blockquote><p><b>another one </b>hello</p><p>hi</p></blockquote>',
+        '<p>what do you think of this craziness</p><blockquote><p><b>another one </b>hello</p><br><p>hi</p></blockquote>',
       ],
     ])('%s → %s', (input, expected) => {
       expect(normalizeHtml(input)).toBe(expected);
@@ -475,6 +475,16 @@ describe('htmlNormalizer', () => {
         )
       ).toBe(
         '<p><b>Asdasdasd</b></p><br><br><p>Sent with <a href="https://google.com">Net</a></p>'
+      );
+    });
+
+    test('<br> between blockquote paragraphs is preserved', () => {
+      expect(
+        normalizeHtml(
+          '<blockquote><p>this is a pretty short blockquote.</p><br><p>This is a line after an empty line.</p></blockquote>'
+        )
+      ).toBe(
+        '<blockquote><p>this is a pretty short blockquote.</p><br><p>This is a line after an empty line.</p></blockquote>'
       );
     });
   });

--- a/src/web/normalization/htmlNormalizer.ts
+++ b/src/web/normalization/htmlNormalizer.ts
@@ -401,7 +401,11 @@ function flattenBqNode(
   }
   if (!isElement(node)) return;
   if (isBrNode(node)) {
-    flushInlineP(ib, out);
+    // Emit the canonical <br> so it is not silently dropped.
+    // With buffered inline content it just terminates the current paragraph.
+    if (!flushInlineP(ib, out)) {
+      out.buf += '<br>';
+    }
     return;
   }
   if (isBlockProducing(node) || isBlockquoteNode(node)) {


### PR DESCRIPTION
# Summary

The `<br>` was getting stripped when inside of a `<blockquote>`

The example HTML that was reproducing the issue:

```html
<html><blockquote><p>this is a pretty short blockquote.</p><br><p>This is a line after an empty line.</p></blockquote></html>
```

## Screenshots

When setting the input's value with that HTML I mentioned in the summary.

Before:

<img width="335" height="82" alt="image" src="https://github.com/user-attachments/assets/3d76e4f1-b2ea-406b-bcbc-3c58ddf853a5" />


After:

<img width="375" height="106" alt="image" src="https://github.com/user-attachments/assets/d83dc9d7-93d0-44e4-9f44-a9f559d52d67" />


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web     |    ✅     |

## Checklist

- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
