### PR TITLE
fix: removing conflicting styles

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/textinput/utils/ShortcutsHandler.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/utils/ShortcutsHandler.kt
@@ -46,7 +46,7 @@ class ShortcutsHandler(
       val resolvedStyle = resolveStyleName(styleName) ?: continue
 
       s.replace(effectiveTriggerStart, effectiveTriggerStart + trigger.length, "")
-      view.toggleStyle(resolvedStyle)
+      view.verifyAndToggleStyle(resolvedStyle)
       return
     }
   }

--- a/ios/utils/ShortcutsUtils.mm
+++ b/ios/utils/ShortcutsUtils.mm
@@ -407,10 +407,12 @@ typedef struct {
 
     input->blockEmitting = NO;
 
-    // Drop conflicting inline typing attrs (e.g. italic) at the cursor before
-    // applying the codeblock style.
+    // Drop conflicting inline styles (e.g. italic) across the whole paragraph
+    // before applying the block style.
+    NSRange paragraphRange = [input->textView.textStorage.string
+        paragraphRangeForRange:input->textView.selectedRange];
     [StyleUtils handleStyleBlocksAndConflicts:type
-                                        range:input->textView.selectedRange
+                                        range:paragraphRange
                                       forHost:input];
 
     [ParagraphAttributesUtils resetTypingAttributes:input


### PR DESCRIPTION
# Summary

 Fix removing conflicting styles when applying paragraph style through shortcut

## Test Plan

1. Type bolded text in paragraph
2. move cursor to the beginning
3. insert codeblock through text shortcuts feature
4. bold should be deleted from this line

## Screenshots / Videos
Before:

https://github.com/user-attachments/assets/80768562-9467-4342-b1ed-e2d0b0c9b520


After:

https://github.com/user-attachments/assets/ed37e9f3-5c4b-4474-8fb2-f20f7315221a


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web     |    ❌     |

## Checklist

- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
