### PR TITLE
fix(web): displaying placeholder image

### DIFF
--- a/src/web/formats/EnrichedImageNodeView.tsx
+++ b/src/web/formats/EnrichedImageNodeView.tsx
@@ -11,7 +11,7 @@ function BrokenImageGlyph() {
       viewBox="0 0 960 960"
       width="100%"
       height="100%"
-      preserveAspectRatio="none"
+      preserveAspectRatio="xMidYMid meet"
       aria-hidden
       focusable="false"
       className="eti-inline-image-broken-glyph"


### PR DESCRIPTION
# Summary

This PR fixes displaying broken image placeholder.

## Test Plan

1. Run example app
2. insert image with wrong url
3. image should be displayed properly

## Screenshots / Videos

Before:
<img width="245" height="148" alt="image" src="https://github.com/user-attachments/assets/3a90251a-175f-4ccb-a6f8-95829e373348" />

After:
<img width="241" height="151" alt="image" src="https://github.com/user-attachments/assets/4d10ae68-8e0f-4178-9683-a83335a791a8" />

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |
| Web     |    ✅     |

## Checklist

- [X] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
