### PR TITLE
fix(iOS): drawing lists in Japanese

### DIFF
--- a/ios/extensions/LayoutManagerExtension.mm
+++ b/ios/extensions/LayoutManagerExtension.mm
@@ -264,6 +264,7 @@ static void const *kInputKey = &kInputKey;
       NSForegroundColorAttributeName : [host.config orderedListMarkerColor]
     };
     CGFloat indent = pStyle.firstLineHeadIndent;
+    UIFont *referenceFont = [host.config primaryFont];
 
     NSArray *paragraphs =
         [RangeUtils getSeparateParagraphsRangesIn:host.textView
@@ -283,13 +284,9 @@ static void const *kInputKey = &kInputKey;
                                      NSUInteger charIdx =
                                          [self characterIndexForGlyphAtIndex:
                                                    lineGlyphRange.location];
-                                     UIFont *font = [host.textView.textStorage
-                                              attribute:NSFontAttributeName
-                                                atIndex:charIdx
-                                         effectiveRange:nil];
-                                     CGRect textUsedRect =
-                                         [self getTextAlignedUsedRect:usedRect
-                                                                 font:font];
+                                     CGRect textUsedRect = [self
+                                         getTextAlignedUsedRect:usedRect
+                                                           font:referenceFont];
 
                                      for (NSTextList *list in pStyle
                                               .textLists) {

--- a/ios/styles/BlockQuoteStyle.mm
+++ b/ios/styles/BlockQuoteStyle.mm
@@ -20,9 +20,13 @@
   return YES;
 }
 
+- (CGFloat)headIndent {
+  return [self.host.config blockquoteBorderWidth] +
+         [self.host.config blockquoteGapWidth];
+}
+
 - (void)applyStyling:(NSRange)range {
-  CGFloat indent = [self.host.config blockquoteBorderWidth] +
-                   [self.host.config blockquoteGapWidth];
+  CGFloat indent = [self headIndent];
   [self.host.textView.textStorage
       enumerateAttribute:NSParagraphStyleAttributeName
                  inRange:range
@@ -49,6 +53,28 @@
   [self.host.textView.textStorage addAttribute:NSStrikethroughColorAttributeName
                                          value:bqColor
                                          range:range];
+}
+
+- (BOOL)appliesStylingToTyping {
+  return YES;
+}
+
+- (void)applyStylingToTypingAttrs:(NSMutableDictionary *)attributes {
+  NSMutableParagraphStyle *pStyle =
+      [attributes[NSParagraphStyleAttributeName] mutableCopy];
+  if (pStyle == nil)
+    return;
+  CGFloat indent = [self headIndent];
+  pStyle.headIndent = indent;
+  pStyle.firstLineHeadIndent = indent;
+  attributes[NSParagraphStyleAttributeName] = pStyle;
+
+  UIColor *bqColor = [self.host.config blockquoteColor];
+  if (bqColor != nil) {
+    attributes[NSForegroundColorAttributeName] = bqColor;
+    attributes[NSUnderlineColorAttributeName] = bqColor;
+    attributes[NSStrikethroughColorAttributeName] = bqColor;
+  }
 }
 
 @end

--- a/ios/styles/CheckboxListStyle.mm
+++ b/ios/styles/CheckboxListStyle.mm
@@ -32,6 +32,11 @@
          [self.host.config checkboxListBoxSize];
 }
 
+- (CGFloat)calculateMinimumLineHeight:(CGFloat)currentLineHeight {
+  CGFloat boxSize = [self.host.config checkboxListBoxSize];
+  return MAX(currentLineHeight, boxSize);
+}
+
 - (void)applyStyling:(NSRange)range {
   CGFloat listHeadIndent = [self headIndent];
 
@@ -45,6 +50,8 @@
                     [(NSParagraphStyle *)value mutableCopy];
                 pStyle.headIndent = listHeadIndent;
                 pStyle.firstLineHeadIndent = listHeadIndent;
+                pStyle.minimumLineHeight =
+                    [self calculateMinimumLineHeight:pStyle.minimumLineHeight];
                 [self.host.textView.textStorage
                     addAttribute:NSParagraphStyleAttributeName
                            value:pStyle
@@ -64,6 +71,8 @@
   CGFloat indent = [self headIndent];
   pStyle.headIndent = indent;
   pStyle.firstLineHeadIndent = indent;
+  pStyle.minimumLineHeight =
+      [self calculateMinimumLineHeight:pStyle.minimumLineHeight];
   attributes[NSParagraphStyleAttributeName] = pStyle;
 }
 

--- a/ios/styles/CheckboxListStyle.mm
+++ b/ios/styles/CheckboxListStyle.mm
@@ -26,10 +26,14 @@
   return YES;
 }
 
+- (CGFloat)headIndent {
+  return [self.host.config checkboxListMarginLeft] +
+         [self.host.config checkboxListGapWidth] +
+         [self.host.config checkboxListBoxSize];
+}
+
 - (void)applyStyling:(NSRange)range {
-  CGFloat listHeadIndent = [self.host.config checkboxListMarginLeft] +
-                           [self.host.config checkboxListGapWidth] +
-                           [self.host.config checkboxListBoxSize];
+  CGFloat listHeadIndent = [self headIndent];
 
   [self.host.textView.textStorage
       enumerateAttribute:NSParagraphStyleAttributeName
@@ -46,6 +50,21 @@
                            value:pStyle
                            range:range];
               }];
+}
+
+- (BOOL)appliesStylingToTyping {
+  return YES;
+}
+
+- (void)applyStylingToTypingAttrs:(NSMutableDictionary *)attributes {
+  NSMutableParagraphStyle *pStyle =
+      [attributes[NSParagraphStyleAttributeName] mutableCopy];
+  if (pStyle == nil)
+    return;
+  CGFloat indent = [self headIndent];
+  pStyle.headIndent = indent;
+  pStyle.firstLineHeadIndent = indent;
+  attributes[NSParagraphStyleAttributeName] = pStyle;
 }
 
 - (BOOL)styleCondition:(id)value range:(NSRange)range {

--- a/ios/styles/CodeBlockStyle.mm
+++ b/ios/styles/CodeBlockStyle.mm
@@ -46,4 +46,22 @@
              range:range];
 }
 
+- (BOOL)appliesStylingToTyping {
+  return YES;
+}
+
+- (void)applyStylingToTypingAttrs:(NSMutableDictionary *)attributes {
+  UIFont *currentFont =
+      attributes[NSFontAttributeName] ?: [self.host.config primaryFont];
+  UIFont *monoFont = [[[self.host.config monospacedFont]
+      withFontTraits:currentFont] setSize:currentFont.pointSize];
+  if (monoFont != nil) {
+    attributes[NSFontAttributeName] = monoFont;
+  }
+  UIColor *fgColor = [self.host.config codeBlockFgColor];
+  if (fgColor != nil) {
+    attributes[NSForegroundColorAttributeName] = fgColor;
+  }
+}
+
 @end

--- a/ios/styles/OrderedListStyle.mm
+++ b/ios/styles/OrderedListStyle.mm
@@ -22,11 +22,15 @@
   return YES;
 }
 
+- (CGFloat)headIndent {
+  return [self.host.config orderedListMarginLeft] +
+         [self.host.config orderedListGapWidth];
+}
+
 - (void)applyStyling:(NSRange)range {
   // lists are drawn manually
   // margin before marker + gap between marker and paragraph
-  CGFloat listHeadIndent = [self.host.config orderedListMarginLeft] +
-                           [self.host.config orderedListGapWidth];
+  CGFloat listHeadIndent = [self headIndent];
 
   [self.host.textView.textStorage
       enumerateAttribute:NSParagraphStyleAttributeName
@@ -43,6 +47,21 @@
                            value:pStyle
                            range:range];
               }];
+}
+
+- (BOOL)appliesStylingToTyping {
+  return YES;
+}
+
+- (void)applyStylingToTypingAttrs:(NSMutableDictionary *)attributes {
+  NSMutableParagraphStyle *pStyle =
+      [attributes[NSParagraphStyleAttributeName] mutableCopy];
+  if (pStyle == nil)
+    return;
+  CGFloat indent = [self headIndent];
+  pStyle.headIndent = indent;
+  pStyle.firstLineHeadIndent = indent;
+  attributes[NSParagraphStyleAttributeName] = pStyle;
 }
 
 @end

--- a/ios/styles/UnorderedListStyle.mm
+++ b/ios/styles/UnorderedListStyle.mm
@@ -22,11 +22,15 @@
   return YES;
 }
 
+- (CGFloat)headIndent {
+  return [self.host.config unorderedListMarginLeft] +
+         [self.host.config unorderedListGapWidth];
+}
+
 - (void)applyStyling:(NSRange)range {
   // lists are drawn manually
   // margin before bullet + gap between bullet and paragraph
-  CGFloat listHeadIndent = [self.host.config unorderedListMarginLeft] +
-                           [self.host.config unorderedListGapWidth];
+  CGFloat listHeadIndent = [self headIndent];
 
   [self.host.textView.textStorage
       enumerateAttribute:NSParagraphStyleAttributeName
@@ -43,6 +47,21 @@
                            value:pStyle
                            range:range];
               }];
+}
+
+- (BOOL)appliesStylingToTyping {
+  return YES;
+}
+
+- (void)applyStylingToTypingAttrs:(NSMutableDictionary *)attributes {
+  NSMutableParagraphStyle *pStyle =
+      [attributes[NSParagraphStyleAttributeName] mutableCopy];
+  if (pStyle == nil)
+    return;
+  CGFloat indent = [self headIndent];
+  pStyle.headIndent = indent;
+  pStyle.firstLineHeadIndent = indent;
+  attributes[NSParagraphStyleAttributeName] = pStyle;
 }
 
 @end


### PR DESCRIPTION
# Summary

Fixes: #728 

This PR:

- preserves list markers when composing Japanese characters in an empty list item by applying the liststyle to the typing attributes
- fixes drawing checkbox when inline code active

## Test Plan

1. Run reproduction steps from issue: #728. The problem should be resolved
2. Toggle checkbox and inline code write something then toggle off inline code and write something -> checkbox should not change its size

## Screenshots / Videos
Before: 

https://github.com/user-attachments/assets/3d39d424-1ba3-4e62-89a0-3c2abc0416a6


After:

https://github.com/user-attachments/assets/0fc61de7-3561-43ab-9313-e3d5858f4c23



## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Web     |    ❌     |

## Checklist

- [x] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
