### PR TITLE
fix: normalizer keeping empty src

### DIFF
--- a/cpp/parser/GumboNormalizer.c
+++ b/cpp/parser/GumboNormalizer.c
@@ -491,7 +491,12 @@ static void emit_attributes(GumboElement *el, const char *tag_name,
   if (strcmp(tag_name, "a") == 0) {
     emit_one_attr(out, el, "href");
   } else if (strcmp(tag_name, "img") == 0) {
-    emit_one_attr(out, el, "src");
+    const char *src_val = get_attr(el, "src");
+    if (src_val && src_val[0]) {
+      emit_one_attr(out, el, "src");
+    } else {
+      buffer_append_str(out, " src=\"\"");
+    }
     emit_one_attr(out, el, "alt");
     emit_one_attr(out, el, "width");
     emit_one_attr(out, el, "height");

--- a/cpp/tests/GumboParserTest.cpp
+++ b/cpp/tests/GumboParserTest.cpp
@@ -282,6 +282,11 @@ TEST(GumboParserTest, EnrichedTagRemappings) {
   EXPECT_EQ(
       GumboParser::normalizeHtml("<img src='x' width='100' height='100' />"),
       "<img src=\"x\" width=\"100\" height=\"100\" />");
+  EXPECT_EQ(GumboParser::normalizeHtml("<img width=\"100\" height=\"100\" />"),
+            "<img src=\"\" width=\"100\" height=\"100\" />");
+  EXPECT_EQ(GumboParser::normalizeHtml(
+                "<img src=\"\" width=\"100\" height=\"100\" />"),
+            "<img src=\"\" width=\"100\" height=\"100\" />");
 
   // Lists
   EXPECT_EQ(GumboParser::normalizeHtml("<ul><li>x</li></ul>"),

--- a/ios/htmlParser/HtmlParser.mm
+++ b/ios/htmlParser/HtmlParser.mm
@@ -670,7 +670,7 @@
       [styleArr addObject:@([ItalicStyle getType])];
     } else if ([tagName isEqualToString:@"img"]) {
       NSRegularExpression *srcRegex =
-          [NSRegularExpression regularExpressionWithPattern:@"src=\"([^\"]+)\""
+          [NSRegularExpression regularExpressionWithPattern:@"src=\"([^\"]*)\""
                                                     options:0
                                                       error:nullptr];
       NSTextCheckingResult *match =

--- a/src/web/__tests__/htmlNormalizer.test.ts
+++ b/src/web/__tests__/htmlNormalizer.test.ts
@@ -262,6 +262,14 @@ describe('htmlNormalizer', () => {
         "<img src='x' width='100' height='100' />",
         '<img src="x" width="100" height="100" />',
       ],
+      [
+        '<img width="100" height="100" />',
+        '<img src="" width="100" height="100" />',
+      ],
+      [
+        '<img src="" width="100" height="100" />',
+        '<img src="" width="100" height="100" />',
+      ],
 
       // Lists
       ['<ul><li>x</li></ul>', '<ul><li>x</li></ul>'],

--- a/src/web/normalization/htmlNormalizer.ts
+++ b/src/web/normalization/htmlNormalizer.ts
@@ -267,7 +267,7 @@ function emitAttributes(el: Element, name: string): string {
       return emitOneAttr(el, 'href');
     case 'img':
       return (
-        emitOneAttr(el, 'src') +
+        (el.getAttribute('src') ? emitOneAttr(el, 'src') : ' src=""') +
         emitOneAttr(el, 'alt') +
         emitOneAttr(el, 'width') +
         emitOneAttr(el, 'height')


### PR DESCRIPTION
# Summary

Now if no `src` attribute is present inside `<img>`, the normalizer adds an empty one - `src=""`. This is done for the sake of structural consistency, which also fixed a couple of issues:

- on web, when you inserted an `<img>` with no `src` attribute, the inline image would get dropped, whereas we want to still display the placeholder
- on iOS and Android, the parser would break if passed an empty `src` or no at all

## Test Plan

Set input's value with a `<img>` tag and a `src=""`, `src="something" and no attribute at all. Each case should have the same effect - a placeholder inline image.

## Screenshots / Videos

iOS

Before:


https://github.com/user-attachments/assets/5fbd6bf4-1170-497e-a539-45fdc7509111



After:


https://github.com/user-attachments/assets/b794d6d9-e3f1-4622-88e3-d677c32812da



## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web     |    ✅     |

## Checklist

- [x] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
