### PR TITLE
fix(android): combining inline styles

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/common/spans/EnrichedInlineCodeSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/common/spans/EnrichedInlineCodeSpan.kt
@@ -11,14 +11,21 @@ open class EnrichedInlineCodeSpan(
 ) : MetricAffectingSpan(),
   EnrichedInlineSpan {
   override fun updateDrawState(textPaint: TextPaint) {
-    val typeface = Typeface.create(Typeface.MONOSPACE, Typeface.NORMAL)
-    textPaint.typeface = typeface
+    applyMonospace(textPaint)
     textPaint.color = enrichedStyle.inlineCodeColor
     textPaint.bgColor = enrichedStyle.inlineCodeBackgroundColor
   }
 
   override fun updateMeasureState(textPaint: TextPaint) {
-    val typeface = Typeface.create(Typeface.MONOSPACE, Typeface.NORMAL)
+    applyMonospace(textPaint)
+  }
+
+  // When switching to a monospace font, we need to remember
+  // and apply other current styles, as bold or italic
+  private fun applyMonospace(textPaint: TextPaint) {
+    val currentStyle = textPaint.typeface?.style ?: Typeface.NORMAL
+    val typeface = Typeface.create(Typeface.MONOSPACE, currentStyle)
+
     textPaint.typeface = typeface
   }
 }

--- a/android/src/main/java/com/swmansion/enriched/common/spans/EnrichedInlineCodeSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/common/spans/EnrichedInlineCodeSpan.kt
@@ -21,7 +21,7 @@ open class EnrichedInlineCodeSpan(
   }
 
   // When switching to a monospace font, we need to remember
-  // and apply other current styles, as bold or italic
+  // and apply other current styles, such as bold or italic.
   private fun applyMonospace(textPaint: TextPaint) {
     val currentStyle = textPaint.typeface?.style ?: Typeface.NORMAL
     val typeface = Typeface.create(Typeface.MONOSPACE, currentStyle)

--- a/android/src/main/java/com/swmansion/enriched/textinput/styles/InlineStyles.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/styles/InlineStyles.kt
@@ -18,7 +18,7 @@ class InlineStyles(
   ) {
     val previousSpanStart = (start - 1).coerceAtLeast(0)
     val previousSpanEnd = previousSpanStart + 1
-    val nextSpanStart = (end + 1).coerceAtMost(spannable.length)
+    val nextSpanStart = end.coerceAtMost(spannable.length)
     val nextSpanEnd = (nextSpanStart + 1).coerceAtMost(spannable.length)
     val previousSpans = spannable.getSpans(previousSpanStart, previousSpanEnd, type)
     val nextSpans = spannable.getSpans(nextSpanStart, nextSpanEnd, type)


### PR DESCRIPTION
# Summary

This PR fixes two bugs regarding inline styles on Android

1. The inline code style was overwriting bold and italic inline styles, as it was switching to monochrome font, and resetting other inline styles by doing that
2. When applying an inline style with the same style present two characters later, they were incorrectly merged

## Test Plan

You can walk-through the test cases in the attached videos below

## Screenshots / Videos

1. bold and italics disappearing in inline code

Before:

https://github.com/user-attachments/assets/915843b9-ec58-4da0-aef0-937d89298b5b

After:

https://github.com/user-attachments/assets/ae139118-ce41-47bd-97b1-7bde3e764af4

2. inline styles incorrectly merging

Before:

https://github.com/user-attachments/assets/331a836f-f273-4f44-b6b5-435d0f32722a

After:

https://github.com/user-attachments/assets/8763503d-a277-4990-98e1-b42ca2fc286c

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Web     |    ❌     |

## Checklist

- [x] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
