### PR TITLE
fix: p tag parsing with alignment

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/common/parser/EnrichedParser.java
+++ b/android/src/main/java/com/swmansion/enriched/common/parser/EnrichedParser.java
@@ -94,8 +94,9 @@ public class EnrichedParser {
     String normalizedBlockQuote =
         normalizedCodeBlock.replaceAll("</blockquote>\\n<br>", "</blockquote>");
 
-    // Replace empty <p> tags (with or without style attributes) with <br>
-    String normalizedHtml = normalizedBlockQuote.replaceAll("<p[^>]*></p>", "<br>");
+    // Replace empty <p> tags with <br>, except when they carry text-align
+    String normalizedHtml =
+        normalizedBlockQuote.replaceAll("<p(?![^>]*text-align\\s*:)[^>]*></p>", "<br>");
 
     return "<html>\n" + normalizedHtml + "</html>";
   }
@@ -593,7 +594,14 @@ class HtmlToSpannedConverter<T> implements ContentHandler {
     if (tag.equalsIgnoreCase("br")) {
       handleBr(mSpannableStringBuilder);
     } else if (tag.equalsIgnoreCase("p")) {
+      boolean empty = isEmptyTag;
+      Alignment pendingAlignment = empty ? getLast(mSpannableStringBuilder, Alignment.class) : null;
       endBlockElement(mSpannableStringBuilder, mSpanFactory);
+      // Plain empty paragraphs never reach setParagraphSpanFromMark (no ZWS).
+      // Represent them as a blank line so they round-trip as <br>.
+      if (empty && pendingAlignment == null) {
+        handleBr(mSpannableStringBuilder);
+      }
     } else if (tag.equalsIgnoreCase("ul")) {
       currentListAlignmentCssValue = null;
       endBlockElement(mSpannableStringBuilder, mSpanFactory);

--- a/ios/htmlParser/HtmlParser.mm
+++ b/ios/htmlParser/HtmlParser.mm
@@ -957,7 +957,16 @@
             inCheckboxList = NO;
           }
         } else {
-          [result appendString:@"\n<br>"];
+          NSString *cssStyleString =
+              [self prepareCssStyleString:currentRange.location
+                             isOpeningTag:YES
+                                     host:host];
+          if (cssStyleString.length > 0) {
+            [result appendString:[NSString stringWithFormat:@"\n<p%@></p>",
+                                                            cssStyleString]];
+          } else {
+            [result appendString:@"\n<br>"];
+          }
         }
       } else {
         // newline finishes a paragraph and all style tags need to be closed
@@ -1456,7 +1465,7 @@
 }
 
 + (void)checkForAlignments:(NSArray *)tagData
-                 plainText:(NSString *)plainText
+                 plainText:(NSMutableString *)plainText
            foundAlignments:(NSMutableArray<AlignmentEntry *> *)foundAlignments
        precedingImageCount:(NSInteger)precedingImageCount {
   if (tagData == nil) {
@@ -1473,6 +1482,12 @@
     // Calculate range relative to plainText
     NSInteger actualStart = startLoc + precedingImageCount;
     NSInteger length = plainText.length - startLoc;
+
+    // Empty aligned paragraphs have no characters to attach alignment to.
+    if (length == 0) {
+      [plainText appendString:@"\u200B"];
+      length = 1;
+    }
 
     if (length > 0) {
       AlignmentEntry *entry = [[AlignmentEntry alloc] init];


### PR DESCRIPTION
# Summary

This PR preserves paragraph alignment on empty paragraphs on mobile.

## Test Plan

Insert input content by `Set Input's value` button:
`<html><p style="text-align: right;">Asdasd</p><p style="text-align: right;"></p><p style="text-align: right;">ddd</p></html>`
And see that alignment on empty p is preserved.

## Screenshots / Videos

https://github.com/user-attachments/assets/c2eff7f8-071e-402b-99c8-7f49b02e1fd4

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web     |    ❌     |

## Checklist

- [X] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
